### PR TITLE
Tabs scrollable

### DIFF
--- a/components/tabs/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/tabs/__tests__/__snapshots__/index.test.tsx.snap
@@ -4,13 +4,20 @@ exports[`Tabs should render correctly 1`] = `
 "<div class=\\"tabs \\"><header class=\\"\\"><div class=\\"tab  \\" role=\\"button\\">label1</div><div class=\\"tab  \\" role=\\"button\\">label2</div></header><div class=\\"content\\"></div><style>
           .tabs {
             width: initial;
+            overflow: auto;
           }
-
+          
           header {
             display: flex;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             align-items: center;
             border-bottom: 1px solid #eaeaea;
+            overflow: scroll;
+            scrollbar-width: none;
+          }
+          
+          header::-webkit-scrollbar {
+            display: none;
           }
 
           .hide-divider {
@@ -28,6 +35,7 @@ exports[`Tabs should render correctly 1`] = `
             transition: all 200ms ease;
             text-transform: capitalize;
             font-size: 1rem;
+            white-space: nowrap;
             margin: 0 calc(0.8 * 8pt);
             color: #444;
             user-select: none;
@@ -79,13 +87,20 @@ exports[`Tabs should work correctly with different styles 1`] = `
 "<div class=\\"tabs \\"><header class=\\"hide-divider\\"><div class=\\"tab  \\" role=\\"button\\">label1</div></header><div class=\\"content\\"></div><style>
           .tabs {
             width: initial;
+            overflow: auto;
           }
-
+          
           header {
             display: flex;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             align-items: center;
             border-bottom: 1px solid #eaeaea;
+            overflow: scroll;
+            scrollbar-width: none;
+          }
+          
+          header::-webkit-scrollbar {
+            display: none;
           }
 
           .hide-divider {
@@ -103,6 +118,7 @@ exports[`Tabs should work correctly with different styles 1`] = `
             transition: all 200ms ease;
             text-transform: capitalize;
             font-size: 1rem;
+            white-space: nowrap;
             margin: 0 calc(0.8 * 8pt);
             color: #444;
             user-select: none;

--- a/components/tabs/tabs.tsx
+++ b/components/tabs/tabs.tsx
@@ -87,13 +87,20 @@ const Tabs: React.FC<React.PropsWithChildren<TabsProps>> = ({
         <style jsx>{`
           .tabs {
             width: initial;
+            overflow: auto;
           }
-
+          
           header {
             display: flex;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             align-items: center;
             border-bottom: 1px solid ${theme.palette.border};
+            overflow: scroll;
+            scrollbar-width: none;
+          }
+          
+          header::-webkit-scrollbar {
+            display: none;
           }
 
           .hide-divider {
@@ -111,6 +118,7 @@ const Tabs: React.FC<React.PropsWithChildren<TabsProps>> = ({
             transition: all 200ms ease;
             text-transform: capitalize;
             font-size: 1rem;
+            white-space: nowrap;
             margin: 0 calc(0.8 * ${theme.layout.gapHalf});
             color: ${theme.palette.accents_6};
             user-select: none;

--- a/lib/components/menu/menu-sticker.tsx
+++ b/lib/components/menu/menu-sticker.tsx
@@ -109,7 +109,6 @@ const MenuSticker = () => {
           display: flex;
           align-items: flex-end;
           height: 100%;
-          overflow: auto;
           z-index: 900;
           margin: 0 auto;
         }
@@ -120,6 +119,7 @@ const MenuSticker = () => {
 
         .inner :global(.tabs),
         .inner :global(header) {
+          width: calc(100% - ${theme.layout.gap});
           height: 100%;
           border: none;
         }

--- a/pages/en-us/components/tabs.mdx
+++ b/pages/en-us/components/tabs.mdx
@@ -69,6 +69,46 @@ Display tab content.
 />
 
 <Playground
+  title="Scroll Behavior"
+  desc="If all tabs cannot fit in the width then then hidden tabs can be accessed through user agent scrolling mechanisms (e.g. left/right swipe, shift-mousewheel, etc.)"
+  scope={{ Tabs, TwitchIcon, TwitterIcon, Link, Text }}
+  code={`
+<Tabs initialValue="1">
+  <Tabs.Item label="Home" value="1">
+    <Text>Hello!</Text>
+  </Tabs.Item>
+  <Tabs.Item label="About" value="2">
+    <Text>Cool stuff.</Text>
+  </Tabs.Item>
+  <Tabs.Item label="About Us" value="3">
+    <Text>Good people.</Text>
+  </Tabs.Item>
+  <Tabs.Item label="Features" value="4">
+    <Text>Amazing.</Text>
+  </Tabs.Item>
+  <Tabs.Item label="Pricing" value="5">
+    <Text>Very low.</Text>
+  </Tabs.Item>
+  <Tabs.Item label="Docs" value="6">
+    <Text>Clear.</Text>
+  </Tabs.Item>
+  <Tabs.Item label="Profile" value="7">
+    <Text>Extraordinary person.</Text>
+  </Tabs.Item>
+  <Tabs.Item label="Settings" value="8">
+    <Text>Easy to tweak.</Text>
+  </Tabs.Item>
+  <Tabs.Item label="Dashboard" value="9">
+    <Text>Charts.</Text>
+  </Tabs.Item>
+  <Tabs.Item label="Policies" value="10">
+    <Text>Privacy focused.</Text>
+  </Tabs.Item>
+</Tabs>
+`}
+/>
+
+<Playground
   title="Imperatively"
   desc="Control components with imperatively style."
   scope={{ Tabs, Button, Spacer, Code, Text, useState }}


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information
- Added overflow to tabs
- Hid scrollbar on tabs
- Made menu sticker compatible with scrollable tabs by assigning correct width
- Added scroll behavior example in docs (english)
- Tab labels now no longer breaks on multiple lines