### PR TITLE
docs: fix useClipboard text

### DIFF
--- a/pages/en-us/components/use-clipboard.mdx
+++ b/pages/en-us/components/use-clipboard.mdx
@@ -43,7 +43,7 @@ type CopyResult = {
   copy: (text: string) => void
 }
 
-const useClickAway = (options?: UseClipboardOptions) => CopyResult
+const useClipboard = (options?: UseClipboardOptions) => CopyResult
 ```
 
 </Attributes>


### PR DESCRIPTION
## Checklist

- [ ] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

Fixed the naming from `useClickAway` to `useClipboard` in the docs for clipboard.
