### PR TITLE
fix(docs): dead links

### DIFF
--- a/pages/en-us/components/display.mdx
+++ b/pages/en-us/components/display.mdx
@@ -16,7 +16,7 @@ To display important information or images in a central alignment.
   scope={{ Display, Image }}
   code={`
   <Display shadow caption="Now for GitHub deploying a pull request automatically.">
-    <Image width="435" height="200" src="https://zeit.co/docs/static/docs/git-integrations/github-comment.png" />
+    <Image width="435" height="200" src="https://vercel.com/docs-proxy/static/docs/git/github-comment.png" />
   </Display>
 `}
 />
@@ -59,8 +59,8 @@ To display important information or images in a central alignment.
   desc="Use component on `caption` prop."
   scope={{ Display, Code, Image }}
   code={`
-  <Display shadow caption={<p>A domain redirect that redirects requests made to <Code>www.zeit.rocks</Code> to <Code>zeit.rocks</Code>.</p>}>
-    <Image width="650" height="297" src="https://zeit.co/docs/static/docs/custom-domains/redirecting-domains.png" />
+  <Display shadow caption={<p>A domain redirect that redirects requests made to <Code>www.acme.com</Code> to <Code>acme.com</Code>.</p>}>
+    <Image width="650" height="297" src="https://vercel.com/docs-proxy/static/docs/custom-domains/redirecting-domains.png" />
   </Display>
 `}
 />

--- a/pages/en-us/components/display.mdx
+++ b/pages/en-us/components/display.mdx
@@ -16,7 +16,7 @@ To display important information or images in a central alignment.
   scope={{ Display, Image }}
   code={`
   <Display shadow caption="Now for GitHub deploying a pull request automatically.">
-    <Image width="435" height="200" src="https://vercel.com/docs-proxy/static/docs/git/github-comment.png" />
+    <Image width="1538" height="660" src="https://vercel.com/docs-proxy/static/docs/git/github-comment.png" />
   </Display>
 `}
 />
@@ -60,7 +60,7 @@ To display important information or images in a central alignment.
   scope={{ Display, Code, Image }}
   code={`
   <Display shadow caption={<p>A domain redirect that redirects requests made to <Code>www.acme.com</Code> to <Code>acme.com</Code>.</p>}>
-    <Image width="650" height="297" src="https://vercel.com/docs-proxy/static/docs/custom-domains/redirecting-domains.png" />
+    <Image width="1496" height="662" src="https://vercel.com/docs-proxy/static/docs/custom-domains/redirecting-domains.png" />
   </Display>
 `}
 />


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information
`zeit.com/docs` has been moved to `vercel.com/docs` causing some links to be dead.
This fixes two of them on the `/en-us/components/display`.

Before:
![Dead](https://user-images.githubusercontent.com/41478382/98819508-f3bb7900-2452-11eb-8fcf-afde7ee0b92e.PNG)
After:
![Correct](https://user-images.githubusercontent.com/41478382/98819529-f918c380-2452-11eb-894b-6d31b5135866.PNG)
