### PR TITLE
ci: auto add dist-tag when publish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,21 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - name: install
         run: yarn install --check-files --frozen-lockfile
+      - name: set dist-tag
+        run: |
+          case "${{github.event.release.name}}" in
+          *"rc"* | *"canary"*)
+           echo "r_tag=canary" >> $GITHUB_ENV;;
+          *"dev"*)
+           echo "r_tag=dev" >> $GITHUB_ENV;;
+          *"beta"*)
+           echo "r_tag=beta" >> $GITHUB_ENV;;
+          *)
+           echo "r_tag=latest" >> $GITHUB_ENV;;
+          esac
       - name: publish
-        run: yarn release
+        run: |
+          echo ">> dist-tag: ${{ env.r_tag }}"
+          yarn release --tag ${{ env.r_tag }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

The `dist-tag` information is now automatically added when the package is published, this will help to improve the version semantics of the current library.

## Future Changes

1. Will does not install `canary` by default: `yarn add @geist-ui/react`.
2. Specify `next` before install the `canary` version: `yarn add @geist-ui/react@next`.