### PR TITLE
chore(docs): update spectrum link with github discussions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,4 +63,4 @@ At any time, you think it's ok, you can start the following steps to submit your
 ### Get stuck
 
 - Create new issue to tell us: [create issue](https://github.com/geist-org/react/issues/new/choose).
-- Ask in [chat room](https://spectrum.chat/geist-ui/react?tab=posts).
+- Ask on [GitHub Discussions](https://github.com/geist-org/react/discussions).


### PR DESCRIPTION
## Change information

Spectrum Chat is going `read-only` being replaced by Github Discussions.

