### PR TITLE
build: ignore the example folder when build document site

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,9 @@
   },
   "exclude": [
     "node_modules",
-    "es"
+    "es",
+    "examples",
+    "dist"
   ],
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

Resolve build failures similar to #524 . (Disable NextJS from checking for unwanted folders at build time)