### PR TITLE
feat: add status prop in checkbox, radio, select, slider and toggle

### DIFF
--- a/components/auto-complete/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/auto-complete/__tests__/__snapshots__/index.test.tsx.snap
@@ -10,5 +10,6 @@ exports[`AutoComplete should render correctly 1`] = `
   initialValue=""
   options={Array []}
   size="medium"
+  type="default"
 />
 `;

--- a/components/auto-complete/__tests__/index.test.tsx
+++ b/components/auto-complete/__tests__/index.test.tsx
@@ -14,8 +14,8 @@ describe('AutoComplete', () => {
   it('should support sizes and status', () => {
     const wrapper = mount(
       <div>
-        <AutoComplete status="secondary" />
-        <AutoComplete status="success" />
+        <AutoComplete type="secondary" />
+        <AutoComplete type="success" />
         <AutoComplete size="mini" />
         <AutoComplete size="large" />
       </div>,

--- a/components/auto-complete/auto-complete.tsx
+++ b/components/auto-complete/auto-complete.tsx
@@ -31,7 +31,7 @@ export type AutoCompleteOptions = Array<
 interface Props {
   options: AutoCompleteOptions
   size?: NormalSizes
-  status?: NormalTypes
+  type?: NormalTypes
   initialValue?: string
   value?: string
   width?: string
@@ -53,6 +53,7 @@ const defaultProps = {
   disabled: false,
   clearable: false,
   size: 'medium' as NormalSizes,
+  type: 'default' as NormalTypes,
   disableMatchWidth: false,
   disableFreeSolo: false,
   className: '',
@@ -94,7 +95,7 @@ const AutoComplete = React.forwardRef<
       searching,
       children,
       size,
-      status,
+      type,
       value,
       width,
       clearable,
@@ -209,7 +210,7 @@ const AutoComplete = React.forwardRef<
           <Input
             ref={inputRef}
             size={size}
-            status={status}
+            type={type}
             onChange={onInputChange}
             onFocus={() => toggleFocusHandler(true)}
             onBlur={() => toggleFocusHandler(false)}

--- a/components/badge/badge.tsx
+++ b/components/badge/badge.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 import useTheme from '../use-theme'
 import { NormalSizes, NormalTypes } from '../utils/prop-types'
-import { GeistUIThemesPalette } from 'components/themes/presets'
+import { GeistUIThemesPalette } from '../themes/presets'
 import BadgeAnchor from './badge-anchor'
 
 interface Props {

--- a/components/button-group/button-group.tsx
+++ b/components/button-group/button-group.tsx
@@ -3,7 +3,7 @@ import useTheme from '../use-theme'
 import withDefaults from '../utils/with-defaults'
 import { NormalSizes, ButtonTypes } from '../utils/prop-types'
 import { ButtonGroupContext, ButtonGroupConfig } from './button-group-context'
-import { GeistUIThemesPalette } from 'components/themes/presets'
+import { GeistUIThemesPalette } from '../themes/presets'
 
 interface Props {
   disabled?: boolean

--- a/components/button/utils.tsx
+++ b/components/button/utils.tsx
@@ -1,8 +1,8 @@
 import React, { ReactNode } from 'react'
 import { NormalSizes } from '../utils/prop-types'
 import ButtonIcon from './button-icon'
-import { ButtonProps } from 'components/button/button'
-import { ButtonGroupConfig } from 'components/button-group/button-group-context'
+import { ButtonProps } from './button'
+import { ButtonGroupConfig } from '../button-group/button-group-context'
 
 export const getButtonChildrenWithIcon = (
   auto: boolean,

--- a/components/checkbox/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/checkbox/__tests__/__snapshots__/index.test.tsx.snap
@@ -1041,3 +1041,171 @@ exports[`Checkbox should work correctly with different sizes 1`] = `
         }
       </style></label></div>"
 `;
+
+exports[`Checkbox should work with different status 1`] = `
+"<div><label class=\\"\\"><svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 12 12\\" fill=\\"none\\"><path d=\\"M8.5 0.5H3.5C1.84315 0.5 0.5 1.84315 0.5 3.5V8.5C0.5 10.1569 1.84315 11.5 3.5 11.5H8.5C10.1569 11.5 11.5 10.1569 11.5 8.5V3.5C11.5 1.84315 10.1569 0.5 8.5 0.5Z\\" stroke=\\"#666\\"></path></svg><style>
+        svg {
+          display: inline-flex;
+          width: calc(0.86 * var(--checkbox-size));
+          height: calc(0.86 * var(--checkbox-size));
+          user-select: none;
+          opacity: 1;
+          cursor: pointer;
+        }
+      </style><input type=\\"checkbox\\"><span class=\\"text\\"></span><style>
+        label {
+          --checkbox-size: .875rem;
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+          width: auto;
+          cursor: pointer;
+          opacity: 1;
+          height: var(--checkbox-size);
+          line-height: var(--checkbox-size);
+        }
+
+        .text {
+          font-size: var(--checkbox-size);
+          line-height: var(--checkbox-size);
+          padding-left: calc(var(--checkbox-size) * 0.57);
+          user-select: none;
+          cursor: pointer;
+        }
+
+        input {
+          opacity: 0;
+          outline: none;
+          position: absolute;
+          width: 0;
+          height: 0;
+          margin: 0;
+          padding: 0;
+          z-index: -1;
+          background-color: transparent;
+        }
+      </style></label><label class=\\"\\"><svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 12 12\\" fill=\\"none\\"><path d=\\"M8.5 0.5H3.5C1.84315 0.5 0.5 1.84315 0.5 3.5V8.5C0.5 10.1569 1.84315 11.5 3.5 11.5H8.5C10.1569 11.5 11.5 10.1569 11.5 8.5V3.5C11.5 1.84315 10.1569 0.5 8.5 0.5Z\\" stroke=\\"#666\\"></path></svg><style>
+        svg {
+          display: inline-flex;
+          width: calc(0.86 * var(--checkbox-size));
+          height: calc(0.86 * var(--checkbox-size));
+          user-select: none;
+          opacity: 1;
+          cursor: pointer;
+        }
+      </style><input type=\\"checkbox\\"><span class=\\"text\\"></span><style>
+        label {
+          --checkbox-size: .875rem;
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+          width: auto;
+          cursor: pointer;
+          opacity: 1;
+          height: var(--checkbox-size);
+          line-height: var(--checkbox-size);
+        }
+
+        .text {
+          font-size: var(--checkbox-size);
+          line-height: var(--checkbox-size);
+          padding-left: calc(var(--checkbox-size) * 0.57);
+          user-select: none;
+          cursor: pointer;
+        }
+
+        input {
+          opacity: 0;
+          outline: none;
+          position: absolute;
+          width: 0;
+          height: 0;
+          margin: 0;
+          padding: 0;
+          z-index: -1;
+          background-color: transparent;
+        }
+      </style></label><label class=\\"\\"><svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 12 12\\" fill=\\"none\\"><path d=\\"M8.5 0.5H3.5C1.84315 0.5 0.5 1.84315 0.5 3.5V8.5C0.5 10.1569 1.84315 11.5 3.5 11.5H8.5C10.1569 11.5 11.5 10.1569 11.5 8.5V3.5C11.5 1.84315 10.1569 0.5 8.5 0.5Z\\" stroke=\\"#666\\"></path></svg><style>
+        svg {
+          display: inline-flex;
+          width: calc(0.86 * var(--checkbox-size));
+          height: calc(0.86 * var(--checkbox-size));
+          user-select: none;
+          opacity: 1;
+          cursor: pointer;
+        }
+      </style><input type=\\"checkbox\\"><span class=\\"text\\"></span><style>
+        label {
+          --checkbox-size: .875rem;
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+          width: auto;
+          cursor: pointer;
+          opacity: 1;
+          height: var(--checkbox-size);
+          line-height: var(--checkbox-size);
+        }
+
+        .text {
+          font-size: var(--checkbox-size);
+          line-height: var(--checkbox-size);
+          padding-left: calc(var(--checkbox-size) * 0.57);
+          user-select: none;
+          cursor: pointer;
+        }
+
+        input {
+          opacity: 0;
+          outline: none;
+          position: absolute;
+          width: 0;
+          height: 0;
+          margin: 0;
+          padding: 0;
+          z-index: -1;
+          background-color: transparent;
+        }
+      </style></label><label class=\\"\\"><svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 12 12\\" fill=\\"none\\"><path d=\\"M8.5 0.5H3.5C1.84315 0.5 0.5 1.84315 0.5 3.5V8.5C0.5 10.1569 1.84315 11.5 3.5 11.5H8.5C10.1569 11.5 11.5 10.1569 11.5 8.5V3.5C11.5 1.84315 10.1569 0.5 8.5 0.5Z\\" stroke=\\"#666\\"></path></svg><style>
+        svg {
+          display: inline-flex;
+          width: calc(0.86 * var(--checkbox-size));
+          height: calc(0.86 * var(--checkbox-size));
+          user-select: none;
+          opacity: 1;
+          cursor: pointer;
+        }
+      </style><input type=\\"checkbox\\"><span class=\\"text\\"></span><style>
+        label {
+          --checkbox-size: .875rem;
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+          width: auto;
+          cursor: pointer;
+          opacity: 1;
+          height: var(--checkbox-size);
+          line-height: var(--checkbox-size);
+        }
+
+        .text {
+          font-size: var(--checkbox-size);
+          line-height: var(--checkbox-size);
+          padding-left: calc(var(--checkbox-size) * 0.57);
+          user-select: none;
+          cursor: pointer;
+        }
+
+        input {
+          opacity: 0;
+          outline: none;
+          position: absolute;
+          width: 0;
+          height: 0;
+          margin: 0;
+          padding: 0;
+          z-index: -1;
+          background-color: transparent;
+        }
+      </style></label></div>"
+`;

--- a/components/checkbox/__tests__/index.test.tsx
+++ b/components/checkbox/__tests__/index.test.tsx
@@ -23,6 +23,18 @@ describe('Checkbox', () => {
     expect(() => wrapper.unmount()).not.toThrow()
   })
 
+  it('should work with different status', () => {
+    const wrapper = mount(
+      <div>
+        <Checkbox status="secondary" />
+        <Checkbox status="success" />
+        <Checkbox status="warning" />
+        <Checkbox status="error" />
+      </div>,
+    )
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should work correctly with initial value', () => {
     let wrapper = mount(<Checkbox checked={true}>Sydney</Checkbox>)
     let input = wrapper.find('input').getDOMNode()

--- a/components/checkbox/__tests__/index.test.tsx
+++ b/components/checkbox/__tests__/index.test.tsx
@@ -26,10 +26,10 @@ describe('Checkbox', () => {
   it('should work with different status', () => {
     const wrapper = mount(
       <div>
-        <Checkbox status="secondary" />
-        <Checkbox status="success" />
-        <Checkbox status="warning" />
-        <Checkbox status="error" />
+        <Checkbox type="secondary" />
+        <Checkbox type="success" />
+        <Checkbox type="warning" />
+        <Checkbox type="error" />
       </div>,
     )
     expect(wrapper.html()).toMatchSnapshot()

--- a/components/checkbox/checkbox.icon.tsx
+++ b/components/checkbox/checkbox.icon.tsx
@@ -4,16 +4,17 @@ import useTheme from '../use-theme'
 interface Props {
   disabled?: boolean
   checked?: boolean
+  fill?: string
+  bg?: string
 }
 
-const CheckboxIcon: React.FC<Props> = ({ disabled, checked }) => {
+const CheckboxIcon: React.FC<Props> = ({ fill, bg, disabled, checked }) => {
   const theme = useTheme()
 
-  const { fill, bg, stroke } = useMemo(() => {
+  const { _fill, _bg } = useMemo(() => {
     return {
-      fill: theme.palette.foreground,
-      bg: theme.palette.background,
-      stroke: theme.palette.accents_5,
+      _fill: fill,
+      _bg: bg,
     }
   }, [theme.palette])
 
@@ -23,15 +24,15 @@ const CheckboxIcon: React.FC<Props> = ({ disabled, checked }) => {
         <svg viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path
             d="M12.1429 0H3.85714C1.7269 0 0 1.79086 0 4V12C0 14.2091 1.7269 16 3.85714 16H12.1429C14.2731 16 16 14.2091 16 12V4C16 1.79086 14.2731 0 12.1429 0Z"
-            fill={fill}
+            fill={_fill}
           />
-          <path d="M16 3L7.72491 11L5 8" stroke={bg} strokeWidth="1.5" />
+          <path d="M16 3L7.72491 11L5 8" stroke={_bg} strokeWidth="1.5" />
         </svg>
       ) : (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none">
           <path
             d="M8.5 0.5H3.5C1.84315 0.5 0.5 1.84315 0.5 3.5V8.5C0.5 10.1569 1.84315 11.5 3.5 11.5H8.5C10.1569 11.5 11.5 10.1569 11.5 8.5V3.5C11.5 1.84315 10.1569 0.5 8.5 0.5Z"
-            stroke={stroke}
+            stroke={theme.palette.accents_5}
           />
         </svg>
       )}

--- a/components/checkbox/checkbox.icon.tsx
+++ b/components/checkbox/checkbox.icon.tsx
@@ -11,10 +11,10 @@ interface Props {
 const CheckboxIcon: React.FC<Props> = ({ fill, bg, disabled, checked }) => {
   const theme = useTheme()
 
-  const { _fill, _bg } = useMemo(() => {
+  const { propsFill, propsBg } = useMemo(() => {
     return {
-      _fill: fill,
-      _bg: bg,
+      propsFill: fill,
+      propsBg: bg,
     }
   }, [theme.palette])
 
@@ -24,9 +24,9 @@ const CheckboxIcon: React.FC<Props> = ({ fill, bg, disabled, checked }) => {
         <svg viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path
             d="M12.1429 0H3.85714C1.7269 0 0 1.79086 0 4V12C0 14.2091 1.7269 16 3.85714 16H12.1429C14.2731 16 16 14.2091 16 12V4C16 1.79086 14.2731 0 12.1429 0Z"
-            fill={_fill}
+            fill={propsFill}
           />
-          <path d="M16 3L7.72491 11L5 8" stroke={_bg} strokeWidth="1.5" />
+          <path d="M16 3L7.72491 11L5 8" stroke={propsBg} strokeWidth="1.5" />
         </svg>
       ) : (
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" fill="none">

--- a/components/checkbox/checkbox.tsx
+++ b/components/checkbox/checkbox.tsx
@@ -3,7 +3,9 @@ import { useCheckbox } from './checkbox-context'
 import CheckboxGroup, { getCheckboxSize } from './checkbox-group'
 import CheckboxIcon from './checkbox.icon'
 import useWarning from '../utils/use-warning'
-import { NormalSizes } from '../utils/prop-types'
+import { NormalSizes, NormalTypes } from '../utils/prop-types'
+import { getColors } from './styles'
+import useTheme from '../use-theme'
 
 interface CheckboxEventTarget {
   checked: boolean
@@ -19,6 +21,7 @@ export interface CheckboxEvent {
 interface Props {
   checked?: boolean
   disabled?: boolean
+  status?: NormalTypes
   initialChecked?: boolean
   onChange?: (e: CheckboxEvent) => void
   size?: NormalSizes
@@ -28,6 +31,7 @@ interface Props {
 
 const defaultProps = {
   disabled: false,
+  status: 'default' as NormalTypes,
   initialChecked: false,
   size: 'small' as NormalSizes,
   className: '',
@@ -45,9 +49,11 @@ const Checkbox: React.FC<CheckboxProps> = ({
   className,
   children,
   size,
+  status,
   value,
   ...props
 }) => {
+  const theme = useTheme()
   const [selfChecked, setSelfChecked] = useState<boolean>(initialChecked)
   const { updateState, inGroup, disabledAll, values } = useCheckbox()
   const isDisabled = inGroup ? disabledAll || disabled : disabled
@@ -67,6 +73,12 @@ const Checkbox: React.FC<CheckboxProps> = ({
   }
 
   const fontSize = useMemo(() => getCheckboxSize(size), [size])
+
+  const { fill, bg } = useMemo(() => getColors(theme.palette, status), [
+    theme.palette,
+    status,
+  ])
+
   const changeHandle = useCallback(
     (ev: React.ChangeEvent) => {
       if (isDisabled) return
@@ -95,7 +107,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
 
   return (
     <label className={`${className}`}>
-      <CheckboxIcon disabled={isDisabled} checked={selfChecked} />
+      <CheckboxIcon fill={fill} bg={bg} disabled={isDisabled} checked={selfChecked} />
       <input
         type="checkbox"
         disabled={isDisabled}

--- a/components/checkbox/checkbox.tsx
+++ b/components/checkbox/checkbox.tsx
@@ -21,7 +21,7 @@ export interface CheckboxEvent {
 interface Props {
   checked?: boolean
   disabled?: boolean
-  status?: NormalTypes
+  type?: NormalTypes
   initialChecked?: boolean
   onChange?: (e: CheckboxEvent) => void
   size?: NormalSizes
@@ -31,7 +31,7 @@ interface Props {
 
 const defaultProps = {
   disabled: false,
-  status: 'default' as NormalTypes,
+  type: 'default' as NormalTypes,
   initialChecked: false,
   size: 'small' as NormalSizes,
   className: '',
@@ -49,7 +49,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
   className,
   children,
   size,
-  status,
+  type,
   value,
   ...props
 }) => {
@@ -74,9 +74,9 @@ const Checkbox: React.FC<CheckboxProps> = ({
 
   const fontSize = useMemo(() => getCheckboxSize(size), [size])
 
-  const { fill, bg } = useMemo(() => getColors(theme.palette, status), [
+  const { fill, bg } = useMemo(() => getColors(theme.palette, type), [
     theme.palette,
-    status,
+    type,
   ])
 
   const changeHandle = useCallback(

--- a/components/checkbox/styles.ts
+++ b/components/checkbox/styles.ts
@@ -1,0 +1,38 @@
+import { GeistUIThemesPalette } from 'components/themes/presets'
+import { NormalTypes } from 'components/utils/prop-types'
+
+export type CheckboxColor = {
+  fill: string
+  bg: string
+}
+
+export const getColors = (
+  palette: GeistUIThemesPalette,
+  status?: NormalTypes,
+): CheckboxColor => {
+  const colors: { [key in NormalTypes]: CheckboxColor } = {
+    default: {
+      fill: palette.foreground,
+      bg: palette.background,
+    },
+    secondary: {
+      fill: palette.foreground,
+      bg: palette.background,
+    },
+    success: {
+      fill: palette.success, // fondo
+      bg: palette.background,
+    },
+    warning: {
+      fill: palette.warning,
+      bg: palette.background,
+    },
+    error: {
+      fill: palette.error,
+      bg: palette.background,
+    },
+  }
+
+  if (!status) return colors.default
+  return colors[status]
+}

--- a/components/checkbox/styles.ts
+++ b/components/checkbox/styles.ts
@@ -1,5 +1,5 @@
-import { GeistUIThemesPalette } from 'components/themes/presets'
-import { NormalTypes } from 'components/utils/prop-types'
+import { GeistUIThemesPalette } from '../themes/presets'
+import { NormalTypes } from '../utils/prop-types'
 
 export type CheckboxColor = {
   fill: string

--- a/components/divider/divider.tsx
+++ b/components/divider/divider.tsx
@@ -3,7 +3,7 @@ import useTheme from '../use-theme'
 import withDefaults from '../utils/with-defaults'
 import { DividerAlign, SnippetTypes } from '../utils/prop-types'
 import { getMargin } from '../spacer/spacer'
-import { GeistUIThemesPalette } from 'components/themes/presets'
+import { GeistUIThemesPalette } from '../themes/presets'
 
 export type DividerTypes = SnippetTypes
 

--- a/components/image/styles.ts
+++ b/components/image/styles.ts
@@ -1,4 +1,4 @@
-import { GeistUIThemesPalette } from 'components/themes/presets'
+import { GeistUIThemesPalette } from '../themes/presets'
 
 export type BrowserColors = {
   color: string

--- a/components/input/__tests__/index.test.tsx
+++ b/components/input/__tests__/index.test.tsx
@@ -24,9 +24,9 @@ describe('Input', () => {
   it('should work with different status', () => {
     const wrapper = mount(
       <div>
-        <Input status="secondary" />
-        <Input status="success" />
-        <Input status="warning" />
+        <Input type="secondary" />
+        <Input type="success" />
+        <Input type="warning" />
       </div>,
     )
     expect(wrapper.html()).toMatchSnapshot()

--- a/components/input/input-props.ts
+++ b/components/input/input-props.ts
@@ -6,7 +6,8 @@ export interface Props {
   initialValue?: string
   placeholder?: string
   size?: NormalSizes
-  status?: NormalTypes
+  type?: NormalTypes
+  hymlType?: string
   readOnly?: boolean
   disabled?: boolean
   label?: string
@@ -32,7 +33,8 @@ export const defaultProps = {
   iconClickable: false,
   width: 'initial',
   size: 'medium' as NormalSizes,
-  status: 'default' as NormalTypes,
+  type: 'default' as NormalTypes,
+  htmlType: 'text',
   autoComplete: 'off',
   className: '',
   placeholder: '',

--- a/components/input/input-props.ts
+++ b/components/input/input-props.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import { NormalSizes, NormalTypes } from 'components/utils/prop-types'
+import { NormalSizes, NormalTypes } from '../utils/prop-types'
 
 export interface Props {
   value?: string

--- a/components/input/input.tsx
+++ b/components/input/input.tsx
@@ -37,7 +37,8 @@ const Input = React.forwardRef<HTMLInputElement, React.PropsWithChildren<InputPr
       label,
       labelRight,
       size,
-      status,
+      type,
+      htmlType,
       icon,
       iconRight,
       iconClickable,
@@ -77,8 +78,8 @@ const Input = React.forwardRef<HTMLInputElement, React.PropsWithChildren<InputPr
       [icon, iconRight],
     )
     const { color, borderColor, hoverBorder } = useMemo(
-      () => getColors(theme.palette, status),
-      [theme.palette, status],
+      () => getColors(theme.palette, type),
+      [theme.palette, type],
     )
 
     const changeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -145,7 +146,7 @@ const Input = React.forwardRef<HTMLInputElement, React.PropsWithChildren<InputPr
             } ${labelClasses}`}>
             {icon && <InputIcon icon={icon} {...iconProps} />}
             <input
-              type="text"
+              type={htmlType}
               ref={inputRef}
               className={`${disabled ? 'disabled' : ''} ${iconClasses}`}
               placeholder={placeholder}

--- a/components/input/password.tsx
+++ b/components/input/password.tsx
@@ -38,7 +38,7 @@ const InputPassword = React.forwardRef<
       ref: inputRef,
       iconClickable: true,
       onIconClick: iconClickHandler,
-      type: visible ? 'text' : 'password',
+      htmlType: visible ? 'text' : 'password',
     }),
     [props, iconClickHandler, visible, inputRef],
   )

--- a/components/loading/loading.tsx
+++ b/components/loading/loading.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react'
 import useTheme from '../use-theme'
 import withDefaults from '../utils/with-defaults'
-import { NormalSizes, NormalTypes } from 'components/utils/prop-types'
-import { GeistUIThemesPalette } from 'components/themes/presets'
+import { NormalSizes, NormalTypes } from '../utils/prop-types'
+import { GeistUIThemesPalette } from '../themes/presets'
 
 type LoadingSizes = NormalSizes | string
 

--- a/components/progress/progress.tsx
+++ b/components/progress/progress.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import withDefaults from '../utils/with-defaults'
 import useTheme from '../use-theme'
 import { useProportions } from '../utils/calculations'
-import { GeistUIThemesPalette } from 'components/themes/presets'
-import { NormalTypes } from 'components/utils/prop-types'
+import { GeistUIThemesPalette } from '../themes/presets'
+import { NormalTypes } from '../utils/prop-types'
 
 export type ProgressColors = {
   [key: number]: string

--- a/components/radio/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/radio/__tests__/__snapshots__/index.test.tsx.snap
@@ -535,3 +535,263 @@ exports[`Radio should work correctly with different sizes 1`] = `
         }
       </style></div></div>"
 `;
+
+exports[`Radio should work with different status 1`] = `
+"<div><div class=\\"radio \\"><label><input type=\\"radio\\" value=\\"\\"><span class=\\"name\\"><span class=\\"point \\"></span></span></label><style>
+        input {
+          opacity: 0;
+          visibility: hidden;
+          overflow: hidden;
+          width: 1px;
+          height: 1px;
+          top: -1000px;
+          right: -1000px;
+          position: fixed;
+        }
+
+        .radio {
+          display: flex;
+          width: initial;
+          align-items: flex-start;
+          position: relative;
+          --radio-size: 16px;
+        }
+
+        label {
+          display: flex;
+          flex-direction: column;
+          justify-content: flex-start;
+          color: #000;
+          cursor: pointer;
+        }
+
+        .name {
+          font-size: var(--radio-size);
+          font-weight: bold;
+          user-select: none;
+          display: inline-flex;
+          align-items: center;
+        }
+
+        .point {
+          height: var(--radio-size);
+          width: var(--radio-size);
+          border-radius: 50%;
+          border: 1px solid #eaeaea;
+          transition: all 0.2s ease 0s;
+          position: relative;
+          display: inline-block;
+          transform: scale(0.875);
+          margin-right: calc(var(--radio-size) * 0.375);
+        }
+
+        .point:before {
+          content: '';
+          position: absolute;
+          left: -1px;
+          top: -1px;
+          transform: scale(0);
+          height: var(--radio-size);
+          width: var(--radio-size);
+          border-radius: 50%;
+          background-color: #000;
+        }
+
+        .point.active:before {
+          transform: scale(0.875);
+          transition: all 0.2s ease 0s;
+        }
+      </style></div><div class=\\"radio \\"><label><input type=\\"radio\\" value=\\"\\"><span class=\\"name\\"><span class=\\"point \\"></span></span></label><style>
+        input {
+          opacity: 0;
+          visibility: hidden;
+          overflow: hidden;
+          width: 1px;
+          height: 1px;
+          top: -1000px;
+          right: -1000px;
+          position: fixed;
+        }
+
+        .radio {
+          display: flex;
+          width: initial;
+          align-items: flex-start;
+          position: relative;
+          --radio-size: 16px;
+        }
+
+        label {
+          display: flex;
+          flex-direction: column;
+          justify-content: flex-start;
+          color: #0070f3;
+          cursor: pointer;
+        }
+
+        .name {
+          font-size: var(--radio-size);
+          font-weight: bold;
+          user-select: none;
+          display: inline-flex;
+          align-items: center;
+        }
+
+        .point {
+          height: var(--radio-size);
+          width: var(--radio-size);
+          border-radius: 50%;
+          border: 1px solid #0070f3;
+          transition: all 0.2s ease 0s;
+          position: relative;
+          display: inline-block;
+          transform: scale(0.875);
+          margin-right: calc(var(--radio-size) * 0.375);
+        }
+
+        .point:before {
+          content: '';
+          position: absolute;
+          left: -1px;
+          top: -1px;
+          transform: scale(0);
+          height: var(--radio-size);
+          width: var(--radio-size);
+          border-radius: 50%;
+          background-color: #0070f3;
+        }
+
+        .point.active:before {
+          transform: scale(0.875);
+          transition: all 0.2s ease 0s;
+        }
+      </style></div><div class=\\"radio \\"><label><input type=\\"radio\\" value=\\"\\"><span class=\\"name\\"><span class=\\"point \\"></span></span></label><style>
+        input {
+          opacity: 0;
+          visibility: hidden;
+          overflow: hidden;
+          width: 1px;
+          height: 1px;
+          top: -1000px;
+          right: -1000px;
+          position: fixed;
+        }
+
+        .radio {
+          display: flex;
+          width: initial;
+          align-items: flex-start;
+          position: relative;
+          --radio-size: 16px;
+        }
+
+        label {
+          display: flex;
+          flex-direction: column;
+          justify-content: flex-start;
+          color: #f5a623;
+          cursor: pointer;
+        }
+
+        .name {
+          font-size: var(--radio-size);
+          font-weight: bold;
+          user-select: none;
+          display: inline-flex;
+          align-items: center;
+        }
+
+        .point {
+          height: var(--radio-size);
+          width: var(--radio-size);
+          border-radius: 50%;
+          border: 1px solid #f5a623;
+          transition: all 0.2s ease 0s;
+          position: relative;
+          display: inline-block;
+          transform: scale(0.875);
+          margin-right: calc(var(--radio-size) * 0.375);
+        }
+
+        .point:before {
+          content: '';
+          position: absolute;
+          left: -1px;
+          top: -1px;
+          transform: scale(0);
+          height: var(--radio-size);
+          width: var(--radio-size);
+          border-radius: 50%;
+          background-color: #f5a623;
+        }
+
+        .point.active:before {
+          transform: scale(0.875);
+          transition: all 0.2s ease 0s;
+        }
+      </style></div><div class=\\"radio \\"><label><input type=\\"radio\\" value=\\"\\"><span class=\\"name\\"><span class=\\"point \\"></span></span></label><style>
+        input {
+          opacity: 0;
+          visibility: hidden;
+          overflow: hidden;
+          width: 1px;
+          height: 1px;
+          top: -1000px;
+          right: -1000px;
+          position: fixed;
+        }
+
+        .radio {
+          display: flex;
+          width: initial;
+          align-items: flex-start;
+          position: relative;
+          --radio-size: 16px;
+        }
+
+        label {
+          display: flex;
+          flex-direction: column;
+          justify-content: flex-start;
+          color: #e00;
+          cursor: pointer;
+        }
+
+        .name {
+          font-size: var(--radio-size);
+          font-weight: bold;
+          user-select: none;
+          display: inline-flex;
+          align-items: center;
+        }
+
+        .point {
+          height: var(--radio-size);
+          width: var(--radio-size);
+          border-radius: 50%;
+          border: 1px solid #e00;
+          transition: all 0.2s ease 0s;
+          position: relative;
+          display: inline-block;
+          transform: scale(0.875);
+          margin-right: calc(var(--radio-size) * 0.375);
+        }
+
+        .point:before {
+          content: '';
+          position: absolute;
+          left: -1px;
+          top: -1px;
+          transform: scale(0);
+          height: var(--radio-size);
+          width: var(--radio-size);
+          border-radius: 50%;
+          background-color: #e00;
+        }
+
+        .point.active:before {
+          transform: scale(0.875);
+          transition: all 0.2s ease 0s;
+        }
+      </style></div></div>"
+`;

--- a/components/radio/__tests__/index.test.tsx
+++ b/components/radio/__tests__/index.test.tsx
@@ -23,6 +23,18 @@ describe('Radio', () => {
     expect(() => wrapper.unmount()).not.toThrow()
   })
 
+  it('should work with different status', () => {
+    const wrapper = mount(
+      <div>
+        <Radio status="secondary" />
+        <Radio status="success" />
+        <Radio status="warning" />
+        <Radio status="error" />
+      </div>,
+    )
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should render correctly with checked prop', () => {
     const wrapper = mount(<Radio>Option</Radio>)
     wrapper.setProps({ checked: false })

--- a/components/radio/__tests__/index.test.tsx
+++ b/components/radio/__tests__/index.test.tsx
@@ -26,10 +26,10 @@ describe('Radio', () => {
   it('should work with different status', () => {
     const wrapper = mount(
       <div>
-        <Radio status="secondary" />
-        <Radio status="success" />
-        <Radio status="warning" />
-        <Radio status="error" />
+        <Radio type="secondary" />
+        <Radio type="success" />
+        <Radio type="warning" />
+        <Radio type="error" />
       </div>,
     )
     expect(wrapper.html()).toMatchSnapshot()

--- a/components/radio/radio-group.tsx
+++ b/components/radio/radio-group.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import withDefaults from '../utils/with-defaults'
 import { RadioContext } from './radio-context'
-import { NormalSizes } from 'components/utils/prop-types'
+import { NormalSizes } from '../utils/prop-types'
 
 interface Props {
   value?: string | number

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -5,7 +5,8 @@ import RadioGroup, { getRadioSize } from './radio-group'
 import RadioDescription from './radio-description'
 import { pickChild } from '../utils/collections'
 import useWarning from '../utils/use-warning'
-import { NormalSizes } from '../utils/prop-types'
+import { NormalSizes, NormalTypes } from '../utils/prop-types'
+import { getColors } from './styles'
 
 interface RadioEventTarget {
   checked: boolean
@@ -22,6 +23,7 @@ interface Props {
   checked?: boolean
   value?: string | number
   size?: NormalSizes
+  status?: NormalTypes
   className?: string
   disabled?: boolean
   onChange?: (e: RadioEvent) => void
@@ -29,6 +31,7 @@ interface Props {
 
 const defaultProps = {
   size: 'medium' as NormalSizes,
+  status: 'default' as NormalTypes,
   disabled: false,
   className: '',
 }
@@ -42,6 +45,7 @@ const Radio: React.FC<React.PropsWithChildren<RadioProps>> = ({
   onChange,
   disabled,
   size,
+  status,
   value: radioValue,
   children,
   ...props
@@ -64,6 +68,12 @@ const Radio: React.FC<React.PropsWithChildren<RadioProps>> = ({
   }
 
   const fontSize = useMemo(() => getRadioSize(size), [size])
+
+  const { label, border, bg } = useMemo(() => getColors(theme.palette, status), [
+    theme.palette,
+    status,
+  ])
+
   const isDisabled = useMemo(() => disabled || disabledAll, [disabled, disabledAll])
   const changeHandler = (event: React.ChangeEvent) => {
     if (isDisabled) return
@@ -128,7 +138,7 @@ const Radio: React.FC<React.PropsWithChildren<RadioProps>> = ({
           display: flex;
           flex-direction: column;
           justify-content: flex-start;
-          color: ${isDisabled ? theme.palette.accents_4 : theme.palette.foreground};
+          color: ${isDisabled ? theme.palette.accents_4 : label};
           cursor: ${isDisabled ? 'not-allowed' : 'pointer'};
         }
 
@@ -144,7 +154,7 @@ const Radio: React.FC<React.PropsWithChildren<RadioProps>> = ({
           height: var(--radio-size);
           width: var(--radio-size);
           border-radius: 50%;
-          border: 1px solid ${theme.palette.border};
+          border: 1px solid ${border};
           transition: all 0.2s ease 0s;
           position: relative;
           display: inline-block;
@@ -161,9 +171,7 @@ const Radio: React.FC<React.PropsWithChildren<RadioProps>> = ({
           height: var(--radio-size);
           width: var(--radio-size);
           border-radius: 50%;
-          background-color: ${isDisabled
-            ? theme.palette.accents_4
-            : theme.palette.foreground};
+          background-color: ${isDisabled ? theme.palette.accents_4 : bg};
         }
 
         .point.active:before {

--- a/components/radio/radio.tsx
+++ b/components/radio/radio.tsx
@@ -23,7 +23,7 @@ interface Props {
   checked?: boolean
   value?: string | number
   size?: NormalSizes
-  status?: NormalTypes
+  type?: NormalTypes
   className?: string
   disabled?: boolean
   onChange?: (e: RadioEvent) => void
@@ -31,7 +31,7 @@ interface Props {
 
 const defaultProps = {
   size: 'medium' as NormalSizes,
-  status: 'default' as NormalTypes,
+  type: 'default' as NormalTypes,
   disabled: false,
   className: '',
 }
@@ -45,7 +45,7 @@ const Radio: React.FC<React.PropsWithChildren<RadioProps>> = ({
   onChange,
   disabled,
   size,
-  status,
+  type,
   value: radioValue,
   children,
   ...props
@@ -69,9 +69,9 @@ const Radio: React.FC<React.PropsWithChildren<RadioProps>> = ({
 
   const fontSize = useMemo(() => getRadioSize(size), [size])
 
-  const { label, border, bg } = useMemo(() => getColors(theme.palette, status), [
+  const { label, border, bg } = useMemo(() => getColors(theme.palette, type), [
     theme.palette,
-    status,
+    type,
   ])
 
   const isDisabled = useMemo(() => disabled || disabledAll, [disabled, disabledAll])

--- a/components/radio/styles.ts
+++ b/components/radio/styles.ts
@@ -1,0 +1,44 @@
+import { GeistUIThemesPalette } from 'components/themes/presets'
+import { NormalTypes } from 'components/utils/prop-types'
+
+export type RadioColor = {
+  label: string
+  border: string
+  bg: string
+}
+
+export const getColors = (
+  palette: GeistUIThemesPalette,
+  status?: NormalTypes,
+): RadioColor => {
+  const colors: { [key in NormalTypes]: RadioColor } = {
+    default: {
+      label: palette.foreground,
+      border: palette.border,
+      bg: palette.foreground,
+    },
+    secondary: {
+      label: palette.foreground,
+      border: palette.border,
+      bg: palette.foreground,
+    },
+    success: {
+      label: palette.success,
+      border: palette.success,
+      bg: palette.success,
+    },
+    warning: {
+      label: palette.warning,
+      border: palette.warning,
+      bg: palette.warning,
+    },
+    error: {
+      label: palette.error,
+      border: palette.error,
+      bg: palette.error,
+    },
+  }
+
+  if (!status) return colors.default
+  return colors[status]
+}

--- a/components/radio/styles.ts
+++ b/components/radio/styles.ts
@@ -1,5 +1,5 @@
-import { GeistUIThemesPalette } from 'components/themes/presets'
-import { NormalTypes } from 'components/utils/prop-types'
+import { GeistUIThemesPalette } from '../themes/presets'
+import { NormalTypes } from '../utils/prop-types'
 
 export type RadioColor = {
   label: string

--- a/components/select/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/index.test.tsx.snap
@@ -1414,3 +1414,363 @@ initialize {
   },
 }
 `;
+
+exports[`Select should work with different status 1`] = `
+"<div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+        span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          line-height: calc(1.688 * 16pt);
+          min-width: 0;
+        }
+      </style></span></span><div class=\\"icon\\"><svg viewBox=\\"0 0 24 24\\" width=\\"1.25em\\" height=\\"1.25em\\" stroke-width=\\"1\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" fill=\\"none\\" shape-rendering=\\"geometricPrecision\\"><path d=\\"M6 9l6 6 6-6\\"></path><style>
+        svg {
+          color: inherit;
+          stroke: currentColor;
+          transition: all 200ms ease;
+        }
+      </style></svg></div><style>
+          .select {
+            display: inline-flex;
+            align-items: center;
+            user-select: none;
+            white-space: nowrap;
+            position: relative;
+            cursor: pointer;
+            max-width: 80vw;
+            width: initial;
+            overflow: hidden;
+            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
+              box-shadow 0.2s ease 0s;
+            border: 1px solid #eaeaea;
+            border-radius: 5px;
+            padding: 0 4pt 0 8pt;
+            height: calc(1.688 * 16pt);
+            min-width: 10rem;
+            background-color: #fff;
+          }
+
+          .multiple {
+            height: auto;
+            min-height: calc(1.688 * 16pt);
+            padding: 4pt calc(.875rem * 2)
+              4pt 8pt;
+          }
+
+          .select:hover {
+            border-color: #000;
+          }
+
+          .select:hover .icon {
+            color: #000;
+          }
+
+          .value {
+            display: inline-flex;
+            flex: 1;
+            height: 100%;
+            align-items: center;
+            line-height: 1;
+            padding: 0;
+            margin-right: 1.25rem;
+            font-size: .875rem;
+            color: #000;
+            width: calc(100% - 1.25rem);
+          }
+
+          .value > :global(div),
+          .value > :global(div:hover) {
+            border-radius: 0;
+            background-color: transparent;
+            padding: 0;
+            margin: 0;
+            color: inherit;
+          }
+
+          .placeholder {
+            color: #999;
+          }
+
+          .icon {
+            position: absolute;
+            right: 4pt;
+            font-size: .875rem;
+            top: 50%;
+            bottom: 0;
+            transform: translateY(-50%) rotate(0deg);
+            pointer-events: none;
+            transition: transform 200ms ease;
+            display: flex;
+            align-items: center;
+            color: #666;
+          }
+        </style></div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+        span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          line-height: calc(1.688 * 16pt);
+          min-width: 0;
+        }
+      </style></span></span><div class=\\"icon\\"><svg viewBox=\\"0 0 24 24\\" width=\\"1.25em\\" height=\\"1.25em\\" stroke-width=\\"1\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" fill=\\"none\\" shape-rendering=\\"geometricPrecision\\"><path d=\\"M6 9l6 6 6-6\\"></path><style>
+        svg {
+          color: inherit;
+          stroke: currentColor;
+          transition: all 200ms ease;
+        }
+      </style></svg></div><style>
+          .select {
+            display: inline-flex;
+            align-items: center;
+            user-select: none;
+            white-space: nowrap;
+            position: relative;
+            cursor: pointer;
+            max-width: 80vw;
+            width: initial;
+            overflow: hidden;
+            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
+              box-shadow 0.2s ease 0s;
+            border: 1px solid #0070f3;
+            border-radius: 5px;
+            padding: 0 4pt 0 8pt;
+            height: calc(1.688 * 16pt);
+            min-width: 10rem;
+            background-color: #fff;
+          }
+
+          .multiple {
+            height: auto;
+            min-height: calc(1.688 * 16pt);
+            padding: 4pt calc(.875rem * 2)
+              4pt 8pt;
+          }
+
+          .select:hover {
+            border-color: #000;
+          }
+
+          .select:hover .icon {
+            color: #000;
+          }
+
+          .value {
+            display: inline-flex;
+            flex: 1;
+            height: 100%;
+            align-items: center;
+            line-height: 1;
+            padding: 0;
+            margin-right: 1.25rem;
+            font-size: .875rem;
+            color: #000;
+            width: calc(100% - 1.25rem);
+          }
+
+          .value > :global(div),
+          .value > :global(div:hover) {
+            border-radius: 0;
+            background-color: transparent;
+            padding: 0;
+            margin: 0;
+            color: inherit;
+          }
+
+          .placeholder {
+            color: #999;
+          }
+
+          .icon {
+            position: absolute;
+            right: 4pt;
+            font-size: .875rem;
+            top: 50%;
+            bottom: 0;
+            transform: translateY(-50%) rotate(0deg);
+            pointer-events: none;
+            transition: transform 200ms ease;
+            display: flex;
+            align-items: center;
+            color: #666;
+          }
+        </style></div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+        span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          line-height: calc(1.688 * 16pt);
+          min-width: 0;
+        }
+      </style></span></span><div class=\\"icon\\"><svg viewBox=\\"0 0 24 24\\" width=\\"1.25em\\" height=\\"1.25em\\" stroke-width=\\"1\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" fill=\\"none\\" shape-rendering=\\"geometricPrecision\\"><path d=\\"M6 9l6 6 6-6\\"></path><style>
+        svg {
+          color: inherit;
+          stroke: currentColor;
+          transition: all 200ms ease;
+        }
+      </style></svg></div><style>
+          .select {
+            display: inline-flex;
+            align-items: center;
+            user-select: none;
+            white-space: nowrap;
+            position: relative;
+            cursor: pointer;
+            max-width: 80vw;
+            width: initial;
+            overflow: hidden;
+            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
+              box-shadow 0.2s ease 0s;
+            border: 1px solid #f5a623;
+            border-radius: 5px;
+            padding: 0 4pt 0 8pt;
+            height: calc(1.688 * 16pt);
+            min-width: 10rem;
+            background-color: #fff;
+          }
+
+          .multiple {
+            height: auto;
+            min-height: calc(1.688 * 16pt);
+            padding: 4pt calc(.875rem * 2)
+              4pt 8pt;
+          }
+
+          .select:hover {
+            border-color: #000;
+          }
+
+          .select:hover .icon {
+            color: #000;
+          }
+
+          .value {
+            display: inline-flex;
+            flex: 1;
+            height: 100%;
+            align-items: center;
+            line-height: 1;
+            padding: 0;
+            margin-right: 1.25rem;
+            font-size: .875rem;
+            color: #000;
+            width: calc(100% - 1.25rem);
+          }
+
+          .value > :global(div),
+          .value > :global(div:hover) {
+            border-radius: 0;
+            background-color: transparent;
+            padding: 0;
+            margin: 0;
+            color: inherit;
+          }
+
+          .placeholder {
+            color: #999;
+          }
+
+          .icon {
+            position: absolute;
+            right: 4pt;
+            font-size: .875rem;
+            top: 50%;
+            bottom: 0;
+            transform: translateY(-50%) rotate(0deg);
+            pointer-events: none;
+            transition: transform 200ms ease;
+            display: flex;
+            align-items: center;
+            color: #666;
+          }
+        </style></div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+        span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          line-height: calc(1.688 * 16pt);
+          min-width: 0;
+        }
+      </style></span></span><div class=\\"icon\\"><svg viewBox=\\"0 0 24 24\\" width=\\"1.25em\\" height=\\"1.25em\\" stroke-width=\\"1\\" stroke-linecap=\\"round\\" stroke-linejoin=\\"round\\" fill=\\"none\\" shape-rendering=\\"geometricPrecision\\"><path d=\\"M6 9l6 6 6-6\\"></path><style>
+        svg {
+          color: inherit;
+          stroke: currentColor;
+          transition: all 200ms ease;
+        }
+      </style></svg></div><style>
+          .select {
+            display: inline-flex;
+            align-items: center;
+            user-select: none;
+            white-space: nowrap;
+            position: relative;
+            cursor: pointer;
+            max-width: 80vw;
+            width: initial;
+            overflow: hidden;
+            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
+              box-shadow 0.2s ease 0s;
+            border: 1px solid #e00;
+            border-radius: 5px;
+            padding: 0 4pt 0 8pt;
+            height: calc(1.688 * 16pt);
+            min-width: 10rem;
+            background-color: #fff;
+          }
+
+          .multiple {
+            height: auto;
+            min-height: calc(1.688 * 16pt);
+            padding: 4pt calc(.875rem * 2)
+              4pt 8pt;
+          }
+
+          .select:hover {
+            border-color: #000;
+          }
+
+          .select:hover .icon {
+            color: #000;
+          }
+
+          .value {
+            display: inline-flex;
+            flex: 1;
+            height: 100%;
+            align-items: center;
+            line-height: 1;
+            padding: 0;
+            margin-right: 1.25rem;
+            font-size: .875rem;
+            color: #000;
+            width: calc(100% - 1.25rem);
+          }
+
+          .value > :global(div),
+          .value > :global(div:hover) {
+            border-radius: 0;
+            background-color: transparent;
+            padding: 0;
+            margin: 0;
+            color: inherit;
+          }
+
+          .placeholder {
+            color: #e00;
+          }
+
+          .icon {
+            position: absolute;
+            right: 4pt;
+            font-size: .875rem;
+            top: 50%;
+            bottom: 0;
+            transform: translateY(-50%) rotate(0deg);
+            pointer-events: none;
+            transition: transform 200ms ease;
+            display: flex;
+            align-items: center;
+            color: #666;
+          }
+        </style></div></div>"
+`;

--- a/components/select/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/index.test.tsx.snap
@@ -26,8 +26,8 @@ exports[`Select should render correctly 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -115,8 +115,8 @@ exports[`Select should render correctly 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -204,8 +204,8 @@ exports[`Select should render correctly 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -293,8 +293,8 @@ exports[`Select should render correctly 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -386,8 +386,8 @@ exports[`Select should work correctly with labels 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -524,8 +524,8 @@ initialize {
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -629,8 +629,8 @@ initialize {
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -899,8 +899,8 @@ initialize {
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -1042,8 +1042,8 @@ initialize {
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -1206,8 +1206,8 @@ initialize {
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -1441,8 +1441,8 @@ exports[`Select should work with different status 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -1530,8 +1530,8 @@ exports[`Select should work with different status 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #0070f3;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -1548,11 +1548,11 @@ exports[`Select should work with different status 1`] = `
           }
 
           .select:hover {
-            border-color: #000;
+            border-color: #0761d1;
           }
 
           .select:hover .icon {
-            color: #000;
+            color: #0761d1;
           }
 
           .value {
@@ -1592,7 +1592,7 @@ exports[`Select should work with different status 1`] = `
             transition: transform 200ms ease;
             display: flex;
             align-items: center;
-            color: #666;
+            color: #0070f3;
           }
         </style></div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
         span {
@@ -1619,8 +1619,8 @@ exports[`Select should work with different status 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #f5a623;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -1637,11 +1637,11 @@ exports[`Select should work with different status 1`] = `
           }
 
           .select:hover {
-            border-color: #000;
+            border-color: #ab570a;
           }
 
           .select:hover .icon {
-            color: #000;
+            color: #ab570a;
           }
 
           .value {
@@ -1681,7 +1681,7 @@ exports[`Select should work with different status 1`] = `
             transition: transform 200ms ease;
             display: flex;
             align-items: center;
-            color: #666;
+            color: #f5a623;
           }
         </style></div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
         span {
@@ -1708,8 +1708,8 @@ exports[`Select should work with different status 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #e00;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;
@@ -1726,11 +1726,11 @@ exports[`Select should work with different status 1`] = `
           }
 
           .select:hover {
-            border-color: #000;
+            border-color: #c50000;
           }
 
           .select:hover .icon {
-            color: #000;
+            color: #c50000;
           }
 
           .value {
@@ -1770,7 +1770,7 @@ exports[`Select should work with different status 1`] = `
             transition: transform 200ms ease;
             display: flex;
             align-items: center;
-            color: #666;
+            color: #e00;
           }
         </style></div></div>"
 `;

--- a/components/select/__tests__/__snapshots__/multiple.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/multiple.test.tsx.snap
@@ -97,8 +97,8 @@ exports[`Select Multiple should render correctly 1`] = `
             max-width: 80vw;
             width: initial;
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid #eaeaea;
             border-radius: 5px;
             padding: 0 4pt 0 8pt;

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -17,6 +17,18 @@ describe('Select', () => {
     expect(() => wrapper.unmount()).not.toThrow()
   })
 
+  it('should work with different status', () => {
+    const wrapper = mount(
+      <div>
+        <Select status="secondary" />
+        <Select status="success" />
+        <Select status="warning" />
+        <Select status="error" />
+      </div>,
+    )
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should work correctly with labels', () => {
     const wrapper = mount(
       <Select>

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -20,10 +20,10 @@ describe('Select', () => {
   it('should work with different status', () => {
     const wrapper = mount(
       <div>
-        <Select status="secondary" />
-        <Select status="success" />
-        <Select status="warning" />
-        <Select status="error" />
+        <Select type="secondary" />
+        <Select type="success" />
+        <Select type="warning" />
+        <Select type="error" />
       </div>,
     )
     expect(wrapper.html()).toMatchSnapshot()

--- a/components/select/select.tsx
+++ b/components/select/select.tsx
@@ -1,5 +1,5 @@
 import React, { CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
-import { NormalSizes } from '../utils/prop-types'
+import { NormalSizes, NormalTypes } from '../utils/prop-types'
 import useTheme from '../use-theme'
 import useClickAway from '../utils/use-click-away'
 import useCurrentState from '../utils/use-current-state'
@@ -10,12 +10,13 @@ import SelectDropdown from './select-dropdown'
 import SelectMultipleValue from './select-multiple-value'
 import Grid from '../grid'
 import { SelectContext, SelectConfig } from './select-context'
-import { getSizes } from './styles'
+import { getColors, getSizes } from './styles'
 import Ellipsis from '../shared/ellipsis'
 
 interface Props {
   disabled?: boolean
   size?: NormalSizes
+  status?: NormalTypes
   value?: string | string[]
   initialValue?: string | string[]
   placeholder?: React.ReactNode | string
@@ -35,6 +36,7 @@ interface Props {
 const defaultProps = {
   disabled: false,
   size: 'medium' as NormalSizes,
+  status: 'default' as NormalTypes,
   icon: SelectIcon as React.ComponentType,
   pure: false,
   multiple: false,
@@ -50,6 +52,7 @@ export type SelectProps = Props & typeof defaultProps & NativeAttrs
 const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
   children,
   size,
+  status,
   disabled,
   initialValue: init,
   value: customValue,
@@ -82,6 +85,11 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
     return value.length === 0
   }, [value])
   const sizes = useMemo(() => getSizes(theme, size), [theme, size])
+
+  const { border, placeholderColor } = useMemo(() => getColors(theme.palette, status), [
+    theme.palette,
+    status,
+  ])
 
   const updateVisible = (next: boolean) => setVisible(next)
   const updateValue = (next: string) => {
@@ -180,7 +188,7 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
             overflow: hidden;
             transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
               box-shadow 0.2s ease 0s;
-            border: 1px solid ${theme.palette.border};
+            border: 1px solid ${border};
             border-radius: ${theme.layout.radius};
             padding: 0 ${theme.layout.gapQuarter} 0 ${theme.layout.gapHalf};
             height: ${sizes.height};
@@ -228,7 +236,7 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
           }
 
           .placeholder {
-            color: ${theme.palette.accents_3};
+            color: ${placeholderColor};
           }
 
           .icon {

--- a/components/select/select.tsx
+++ b/components/select/select.tsx
@@ -16,7 +16,7 @@ import Ellipsis from '../shared/ellipsis'
 interface Props {
   disabled?: boolean
   size?: NormalSizes
-  status?: NormalTypes
+  type?: NormalTypes
   value?: string | string[]
   initialValue?: string | string[]
   placeholder?: React.ReactNode | string
@@ -36,7 +36,7 @@ interface Props {
 const defaultProps = {
   disabled: false,
   size: 'medium' as NormalSizes,
-  status: 'default' as NormalTypes,
+  type: 'default' as NormalTypes,
   icon: SelectIcon as React.ComponentType,
   pure: false,
   multiple: false,
@@ -52,7 +52,7 @@ export type SelectProps = Props & typeof defaultProps & NativeAttrs
 const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
   children,
   size,
-  status,
+  type,
   disabled,
   initialValue: init,
   value: customValue,
@@ -86,9 +86,9 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
   }, [value])
   const sizes = useMemo(() => getSizes(theme, size), [theme, size])
 
-  const { border, placeholderColor } = useMemo(() => getColors(theme.palette, status), [
+  const { border, placeholderColor } = useMemo(() => getColors(theme.palette, type), [
     theme.palette,
-    status,
+    type,
   ])
 
   const updateVisible = (next: boolean) => setVisible(next)

--- a/components/select/select.tsx
+++ b/components/select/select.tsx
@@ -86,10 +86,10 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
   }, [value])
   const sizes = useMemo(() => getSizes(theme, size), [theme, size])
 
-  const { border, placeholderColor } = useMemo(() => getColors(theme.palette, type), [
-    theme.palette,
-    type,
-  ])
+  const { border, borderHover, iconBorder, placeholderColor } = useMemo(
+    () => getColors(theme.palette, type),
+    [theme.palette, type],
+  )
 
   const updateVisible = (next: boolean) => setVisible(next)
   const updateValue = (next: string) => {
@@ -186,8 +186,8 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
             max-width: 80vw;
             width: ${width};
             overflow: hidden;
-            transition: border 0.2s ease 0s, color 0.2s ease-out 0s,
-              box-shadow 0.2s ease 0s;
+            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+              box-shadow 200ms ease 0s;
             border: 1px solid ${border};
             border-radius: ${theme.layout.radius};
             padding: 0 ${theme.layout.gapQuarter} 0 ${theme.layout.gapHalf};
@@ -206,11 +206,11 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
           }
 
           .select:hover {
-            border-color: ${disabled ? theme.palette.border : theme.palette.foreground};
+            border-color: ${disabled ? theme.palette.border : borderHover};
           }
 
           .select:hover .icon {
-            color: ${disabled ? theme.palette.accents_5 : theme.palette.foreground};
+            color: ${disabled ? theme.palette.accents_5 : borderHover};
           }
 
           .value {
@@ -250,7 +250,7 @@ const Select: React.FC<React.PropsWithChildren<SelectProps>> = ({
             transition: transform 200ms ease;
             display: flex;
             align-items: center;
-            color: ${theme.palette.accents_5};
+            color: ${iconBorder};
           }
         `}</style>
       </div>

--- a/components/select/styles.ts
+++ b/components/select/styles.ts
@@ -1,5 +1,5 @@
-import { NormalSizes } from 'components/utils/prop-types'
-import { GeistUIThemes } from 'components/themes/presets'
+import { NormalSizes, NormalTypes } from 'components/utils/prop-types'
+import { GeistUIThemes, GeistUIThemesPalette } from 'components/themes/presets'
 
 export interface SelectSize {
   height: string
@@ -32,4 +32,40 @@ export const getSizes = (theme: GeistUIThemes, size?: NormalSizes) => {
   }
 
   return size ? sizes[size] : sizes.medium
+}
+
+export type SelectColor = {
+  border: string
+  placeholderColor: string
+}
+
+export const getColors = (
+  palette: GeistUIThemesPalette,
+  status?: NormalTypes,
+): SelectColor => {
+  const colors: { [key in NormalTypes]: SelectColor } = {
+    default: {
+      border: palette.border,
+      placeholderColor: palette.accents_3,
+    },
+    secondary: {
+      border: palette.border,
+      placeholderColor: palette.accents_3,
+    },
+    success: {
+      border: palette.success,
+      placeholderColor: palette.accents_3,
+    },
+    warning: {
+      border: palette.warning,
+      placeholderColor: palette.accents_3,
+    },
+    error: {
+      border: palette.error,
+      placeholderColor: palette.error,
+    },
+  }
+
+  if (!status) return colors.default
+  return colors[status]
 }

--- a/components/select/styles.ts
+++ b/components/select/styles.ts
@@ -36,6 +36,8 @@ export const getSizes = (theme: GeistUIThemes, size?: NormalSizes) => {
 
 export type SelectColor = {
   border: string
+  borderHover: string
+  iconBorder: string
   placeholderColor: string
 }
 
@@ -46,22 +48,34 @@ export const getColors = (
   const colors: { [key in NormalTypes]: SelectColor } = {
     default: {
       border: palette.border,
+      borderHover: palette.foreground,
+      iconBorder: palette.accents_5,
       placeholderColor: palette.accents_3,
     },
     secondary: {
       border: palette.border,
+      borderHover: palette.foreground,
+      iconBorder: palette.accents_5,
       placeholderColor: palette.accents_3,
     },
     success: {
       border: palette.success,
+      borderHover: palette.successDark,
+      iconBorder: palette.success,
       placeholderColor: palette.accents_3,
     },
     warning: {
       border: palette.warning,
+      borderHover: palette.warningDark,
+      iconBorder: palette.warning,
+
       placeholderColor: palette.accents_3,
     },
     error: {
       border: palette.error,
+      borderHover: palette.errorDark,
+      iconBorder: palette.error,
+
       placeholderColor: palette.error,
     },
   }

--- a/components/select/styles.ts
+++ b/components/select/styles.ts
@@ -1,5 +1,5 @@
-import { NormalSizes, NormalTypes } from 'components/utils/prop-types'
-import { GeistUIThemes, GeistUIThemesPalette } from 'components/themes/presets'
+import { NormalSizes, NormalTypes } from '../utils/prop-types'
+import { GeistUIThemes, GeistUIThemesPalette } from '../themes/presets'
 
 export interface SelectSize {
   height: string

--- a/components/slider/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/slider/__tests__/__snapshots__/index.test.tsx.snap
@@ -50,6 +50,194 @@ exports[`Slider should render correctly 1`] = `
       </style></div>"
 `;
 
+exports[`Slider should work with different status 1`] = `
+"<div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
+        .dot {
+          position: absolute;
+          left: 0%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          height: 1.25rem;
+          min-width: 1.25rem;
+          line-height: 1.25rem;
+          border-radius: 0.625rem;
+          user-select: none;
+          font-weight: 700;
+          font-size: 0.75rem;
+          z-index: 100;
+          background-color: #0070f3;
+          color: #fff;
+          text-align: center;
+          padding: 0 calc(0.86 * 8pt);
+        }
+
+        .dot.disabled {
+          cursor: not-allowed !important;
+          background-color: #eaeaea;
+          color: #888;
+        }
+
+        .dot.click {
+          transition: all 200ms ease;
+        }
+
+        .dot:hover {
+          cursor: grab;
+        }
+
+        .dot:active {
+          cursor: grabbing;
+        }
+      </style></div><style>
+        .slider {
+          width: 100%;
+          height: 0.5rem;
+          border-radius: 50px;
+          background-color: #111;
+          position: relative;
+          cursor: pointer;
+        }
+      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
+        .dot {
+          position: absolute;
+          left: 0%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          height: 1.25rem;
+          min-width: 1.25rem;
+          line-height: 1.25rem;
+          border-radius: 0.625rem;
+          user-select: none;
+          font-weight: 700;
+          font-size: 0.75rem;
+          z-index: 100;
+          background-color: #0070f3;
+          color: #fff;
+          text-align: center;
+          padding: 0 calc(0.86 * 8pt);
+        }
+
+        .dot.disabled {
+          cursor: not-allowed !important;
+          background-color: #eaeaea;
+          color: #888;
+        }
+
+        .dot.click {
+          transition: all 200ms ease;
+        }
+
+        .dot:hover {
+          cursor: grab;
+        }
+
+        .dot:active {
+          cursor: grabbing;
+        }
+      </style></div><style>
+        .slider {
+          width: 100%;
+          height: 0.5rem;
+          border-radius: 50px;
+          background-color: #0070f3;
+          position: relative;
+          cursor: pointer;
+        }
+      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
+        .dot {
+          position: absolute;
+          left: 0%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          height: 1.25rem;
+          min-width: 1.25rem;
+          line-height: 1.25rem;
+          border-radius: 0.625rem;
+          user-select: none;
+          font-weight: 700;
+          font-size: 0.75rem;
+          z-index: 100;
+          background-color: #0070f3;
+          color: #fff;
+          text-align: center;
+          padding: 0 calc(0.86 * 8pt);
+        }
+
+        .dot.disabled {
+          cursor: not-allowed !important;
+          background-color: #eaeaea;
+          color: #888;
+        }
+
+        .dot.click {
+          transition: all 200ms ease;
+        }
+
+        .dot:hover {
+          cursor: grab;
+        }
+
+        .dot:active {
+          cursor: grabbing;
+        }
+      </style></div><style>
+        .slider {
+          width: 100%;
+          height: 0.5rem;
+          border-radius: 50px;
+          background-color: #f5a623;
+          position: relative;
+          cursor: pointer;
+        }
+      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
+        .dot {
+          position: absolute;
+          left: 0%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          height: 1.25rem;
+          min-width: 1.25rem;
+          line-height: 1.25rem;
+          border-radius: 0.625rem;
+          user-select: none;
+          font-weight: 700;
+          font-size: 0.75rem;
+          z-index: 100;
+          background-color: #0070f3;
+          color: #fff;
+          text-align: center;
+          padding: 0 calc(0.86 * 8pt);
+        }
+
+        .dot.disabled {
+          cursor: not-allowed !important;
+          background-color: #eaeaea;
+          color: #888;
+        }
+
+        .dot.click {
+          transition: all 200ms ease;
+        }
+
+        .dot:hover {
+          cursor: grab;
+        }
+
+        .dot:active {
+          cursor: grabbing;
+        }
+      </style></div><style>
+        .slider {
+          width: 100%;
+          height: 0.5rem;
+          border-radius: 50px;
+          background-color: #e00;
+          position: relative;
+          cursor: pointer;
+        }
+      </style></div></div>"
+`;
+
 exports[`Slider should work with hideValue 1`] = `
 "<div class=\\"slider \\"><div class=\\"dot  \\"><style>
         .dot {
@@ -98,190 +286,6 @@ exports[`Slider should work with hideValue 1`] = `
           cursor: pointer;
         }
       </style></div>"
-`;
-
-exports[`Slider should work with different status 1`] = `
-"<div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
-        .dot {
-          position: absolute;
-          left: 0%;
-          top: 50%;
-          transform: translate(-50%, -50%);
-          height: 1.25rem;
-          line-height: 1.25rem;
-          border-radius: 0.625rem;
-          user-select: none;
-          font-weight: 700;
-          font-size: 0.75rem;
-          z-index: 100;
-          background-color: #0070f3;
-          color: #fff;
-          text-align: center;
-          padding: 0 calc(0.86 * 8pt);
-        }
-
-        .dot.disabled {
-          cursor: not-allowed !important;
-          background-color: #eaeaea;
-          color: #888;
-        }
-
-        .dot.click {
-          transition: all 200ms ease;
-        }
-
-        .dot:hover {
-          cursor: grab;
-        }
-
-        .dot:active {
-          cursor: grabbing;
-        }
-      </style></div><style>
-        .slider {
-          width: 100%;
-          height: 0.5rem;
-          border-radius: 50px;
-          background-color: #111;
-          position: relative;
-          cursor: pointer;
-        }
-      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
-        .dot {
-          position: absolute;
-          left: 0%;
-          top: 50%;
-          transform: translate(-50%, -50%);
-          height: 1.25rem;
-          line-height: 1.25rem;
-          border-radius: 0.625rem;
-          user-select: none;
-          font-weight: 700;
-          font-size: 0.75rem;
-          z-index: 100;
-          background-color: #0070f3;
-          color: #fff;
-          text-align: center;
-          padding: 0 calc(0.86 * 8pt);
-        }
-
-        .dot.disabled {
-          cursor: not-allowed !important;
-          background-color: #eaeaea;
-          color: #888;
-        }
-
-        .dot.click {
-          transition: all 200ms ease;
-        }
-
-        .dot:hover {
-          cursor: grab;
-        }
-
-        .dot:active {
-          cursor: grabbing;
-        }
-      </style></div><style>
-        .slider {
-          width: 100%;
-          height: 0.5rem;
-          border-radius: 50px;
-          background-color: #0070f3;
-          position: relative;
-          cursor: pointer;
-        }
-      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
-        .dot {
-          position: absolute;
-          left: 0%;
-          top: 50%;
-          transform: translate(-50%, -50%);
-          height: 1.25rem;
-          line-height: 1.25rem;
-          border-radius: 0.625rem;
-          user-select: none;
-          font-weight: 700;
-          font-size: 0.75rem;
-          z-index: 100;
-          background-color: #0070f3;
-          color: #fff;
-          text-align: center;
-          padding: 0 calc(0.86 * 8pt);
-        }
-
-        .dot.disabled {
-          cursor: not-allowed !important;
-          background-color: #eaeaea;
-          color: #888;
-        }
-
-        .dot.click {
-          transition: all 200ms ease;
-        }
-
-        .dot:hover {
-          cursor: grab;
-        }
-
-        .dot:active {
-          cursor: grabbing;
-        }
-      </style></div><style>
-        .slider {
-          width: 100%;
-          height: 0.5rem;
-          border-radius: 50px;
-          background-color: #f5a623;
-          position: relative;
-          cursor: pointer;
-        }
-      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
-        .dot {
-          position: absolute;
-          left: 0%;
-          top: 50%;
-          transform: translate(-50%, -50%);
-          height: 1.25rem;
-          line-height: 1.25rem;
-          border-radius: 0.625rem;
-          user-select: none;
-          font-weight: 700;
-          font-size: 0.75rem;
-          z-index: 100;
-          background-color: #0070f3;
-          color: #fff;
-          text-align: center;
-          padding: 0 calc(0.86 * 8pt);
-        }
-
-        .dot.disabled {
-          cursor: not-allowed !important;
-          background-color: #eaeaea;
-          color: #888;
-        }
-
-        .dot.click {
-          transition: all 200ms ease;
-        }
-
-        .dot:hover {
-          cursor: grab;
-        }
-
-        .dot:active {
-          cursor: grabbing;
-        }
-      </style></div><style>
-        .slider {
-          width: 100%;
-          height: 0.5rem;
-          border-radius: 50px;
-          background-color: #e00;
-          position: relative;
-          cursor: pointer;
-        }
-      </style></div></div>"
 `;
 
 exports[`Slider should work with markers 1`] = `

--- a/components/slider/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/slider/__tests__/__snapshots__/index.test.tsx.snap
@@ -100,6 +100,190 @@ exports[`Slider should work with hideValue 1`] = `
       </style></div>"
 `;
 
+exports[`Slider should work with different status 1`] = `
+"<div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
+        .dot {
+          position: absolute;
+          left: 0%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          height: 1.25rem;
+          line-height: 1.25rem;
+          border-radius: 0.625rem;
+          user-select: none;
+          font-weight: 700;
+          font-size: 0.75rem;
+          z-index: 100;
+          background-color: #0070f3;
+          color: #fff;
+          text-align: center;
+          padding: 0 calc(0.86 * 8pt);
+        }
+
+        .dot.disabled {
+          cursor: not-allowed !important;
+          background-color: #eaeaea;
+          color: #888;
+        }
+
+        .dot.click {
+          transition: all 200ms ease;
+        }
+
+        .dot:hover {
+          cursor: grab;
+        }
+
+        .dot:active {
+          cursor: grabbing;
+        }
+      </style></div><style>
+        .slider {
+          width: 100%;
+          height: 0.5rem;
+          border-radius: 50px;
+          background-color: #111;
+          position: relative;
+          cursor: pointer;
+        }
+      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
+        .dot {
+          position: absolute;
+          left: 0%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          height: 1.25rem;
+          line-height: 1.25rem;
+          border-radius: 0.625rem;
+          user-select: none;
+          font-weight: 700;
+          font-size: 0.75rem;
+          z-index: 100;
+          background-color: #0070f3;
+          color: #fff;
+          text-align: center;
+          padding: 0 calc(0.86 * 8pt);
+        }
+
+        .dot.disabled {
+          cursor: not-allowed !important;
+          background-color: #eaeaea;
+          color: #888;
+        }
+
+        .dot.click {
+          transition: all 200ms ease;
+        }
+
+        .dot:hover {
+          cursor: grab;
+        }
+
+        .dot:active {
+          cursor: grabbing;
+        }
+      </style></div><style>
+        .slider {
+          width: 100%;
+          height: 0.5rem;
+          border-radius: 50px;
+          background-color: #0070f3;
+          position: relative;
+          cursor: pointer;
+        }
+      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
+        .dot {
+          position: absolute;
+          left: 0%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          height: 1.25rem;
+          line-height: 1.25rem;
+          border-radius: 0.625rem;
+          user-select: none;
+          font-weight: 700;
+          font-size: 0.75rem;
+          z-index: 100;
+          background-color: #0070f3;
+          color: #fff;
+          text-align: center;
+          padding: 0 calc(0.86 * 8pt);
+        }
+
+        .dot.disabled {
+          cursor: not-allowed !important;
+          background-color: #eaeaea;
+          color: #888;
+        }
+
+        .dot.click {
+          transition: all 200ms ease;
+        }
+
+        .dot:hover {
+          cursor: grab;
+        }
+
+        .dot:active {
+          cursor: grabbing;
+        }
+      </style></div><style>
+        .slider {
+          width: 100%;
+          height: 0.5rem;
+          border-radius: 50px;
+          background-color: #f5a623;
+          position: relative;
+          cursor: pointer;
+        }
+      </style></div><div class=\\"slider \\"><div class=\\"dot  \\">0<style>
+        .dot {
+          position: absolute;
+          left: 0%;
+          top: 50%;
+          transform: translate(-50%, -50%);
+          height: 1.25rem;
+          line-height: 1.25rem;
+          border-radius: 0.625rem;
+          user-select: none;
+          font-weight: 700;
+          font-size: 0.75rem;
+          z-index: 100;
+          background-color: #0070f3;
+          color: #fff;
+          text-align: center;
+          padding: 0 calc(0.86 * 8pt);
+        }
+
+        .dot.disabled {
+          cursor: not-allowed !important;
+          background-color: #eaeaea;
+          color: #888;
+        }
+
+        .dot.click {
+          transition: all 200ms ease;
+        }
+
+        .dot:hover {
+          cursor: grab;
+        }
+
+        .dot:active {
+          cursor: grabbing;
+        }
+      </style></div><style>
+        .slider {
+          width: 100%;
+          height: 0.5rem;
+          border-radius: 50px;
+          background-color: #e00;
+          position: relative;
+          cursor: pointer;
+        }
+      </style></div></div>"
+`;
+
 exports[`Slider should work with markers 1`] = `
 "<div class=\\"slider \\"><div class=\\"dot  \\">0<style>
         .dot {

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -72,10 +72,10 @@ describe('Slider', () => {
   it('should work with different status', () => {
     const wrapper = mount(
       <div>
-        <Slider status="secondary" />
-        <Slider status="success" />
-        <Slider status="warning" />
-        <Slider status="error" />
+        <Slider type="secondary" />
+        <Slider type="success" />
+        <Slider type="warning" />
+        <Slider type="error" />
       </div>,
     )
     expect(wrapper.html()).toMatchSnapshot()

--- a/components/slider/__tests__/index.test.tsx
+++ b/components/slider/__tests__/index.test.tsx
@@ -69,6 +69,18 @@ describe('Slider', () => {
     changeHandler.mockRestore()
   })
 
+  it('should work with different status', () => {
+    const wrapper = mount(
+      <div>
+        <Slider status="secondary" />
+        <Slider status="success" />
+        <Slider status="warning" />
+        <Slider status="error" />
+      </div>,
+    )
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should ignore events when disabled', async () => {
     let value = 0
     const changeHandler = jest.fn().mockImplementation(val => (value = val))

--- a/components/slider/slider.tsx
+++ b/components/slider/slider.tsx
@@ -18,7 +18,7 @@ import { NormalTypes } from 'components/utils/prop-types'
 interface Props {
   hideValue?: boolean
   value?: number
-  status?: NormalTypes
+  type?: NormalTypes
   initialValue?: number
   step?: number
   max?: number
@@ -31,7 +31,7 @@ interface Props {
 
 const defaultProps = {
   hideValue: false,
-  status: 'default' as NormalTypes,
+  type: 'default' as NormalTypes,
   initialValue: 0,
   step: 1,
   min: 0,
@@ -71,7 +71,7 @@ const getValue = (
 const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({
   hideValue,
   disabled,
-  status,
+  type,
   step,
   max,
   min,
@@ -112,7 +112,7 @@ const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({
     [max, min, step, sideWidthRef],
   )
 
-  const { bg } = useMemo(() => getColors(theme.palette, status), [theme.palette, status])
+  const { bg } = useMemo(() => getColors(theme.palette, type), [theme.palette, type])
 
   const dragHandler = (event: DraggingEvent) => {
     if (disabled) return

--- a/components/slider/slider.tsx
+++ b/components/slider/slider.tsx
@@ -13,7 +13,7 @@ import useCurrentState from '../utils/use-current-state'
 import SliderDot from './slider-dot'
 import SliderMark from './slider-mark'
 import { getColors } from './styles'
-import { NormalTypes } from 'components/utils/prop-types'
+import { NormalTypes } from '../utils/prop-types'
 
 interface Props {
   hideValue?: boolean

--- a/components/slider/slider.tsx
+++ b/components/slider/slider.tsx
@@ -12,10 +12,13 @@ import useDrag, { DraggingEvent } from '../utils/use-drag'
 import useCurrentState from '../utils/use-current-state'
 import SliderDot from './slider-dot'
 import SliderMark from './slider-mark'
+import { getColors } from './styles'
+import { NormalTypes } from 'components/utils/prop-types'
 
 interface Props {
   hideValue?: boolean
   value?: number
+  status?: NormalTypes
   initialValue?: number
   step?: number
   max?: number
@@ -28,6 +31,7 @@ interface Props {
 
 const defaultProps = {
   hideValue: false,
+  status: 'default' as NormalTypes,
   initialValue: 0,
   step: 1,
   min: 0,
@@ -67,6 +71,7 @@ const getValue = (
 const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({
   hideValue,
   disabled,
+  status,
   step,
   max,
   min,
@@ -106,6 +111,8 @@ const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({
     },
     [max, min, step, sideWidthRef],
   )
+
+  const { bg } = useMemo(() => getColors(theme.palette, status), [theme.palette, status])
 
   const dragHandler = (event: DraggingEvent) => {
     if (disabled) return
@@ -162,9 +169,7 @@ const Slider: React.FC<React.PropsWithChildren<SliderProps>> = ({
           width: 100%;
           height: 0.5rem;
           border-radius: 50px;
-          background-color: ${disabled
-            ? theme.palette.accents_2
-            : theme.palette.accents_8};
+          background-color: ${disabled ? theme.palette.accents_2 : bg};
           position: relative;
           cursor: ${disabled ? 'not-allow' : 'pointer'};
         }

--- a/components/slider/styles.ts
+++ b/components/slider/styles.ts
@@ -1,0 +1,32 @@
+import { GeistUIThemesPalette } from 'components/themes/presets'
+import { NormalTypes } from 'components/utils/prop-types'
+
+export type SelectColor = {
+  bg: string
+}
+
+export const getColors = (
+  palette: GeistUIThemesPalette,
+  status?: NormalTypes,
+): SelectColor => {
+  const colors: { [key in NormalTypes]: SelectColor } = {
+    default: {
+      bg: palette.accents_8,
+    },
+    secondary: {
+      bg: palette.accents_8,
+    },
+    success: {
+      bg: palette.success,
+    },
+    warning: {
+      bg: palette.warning,
+    },
+    error: {
+      bg: palette.error,
+    },
+  }
+
+  if (!status) return colors.default
+  return colors[status]
+}

--- a/components/slider/styles.ts
+++ b/components/slider/styles.ts
@@ -1,5 +1,5 @@
-import { GeistUIThemesPalette } from 'components/themes/presets'
-import { NormalTypes } from 'components/utils/prop-types'
+import { GeistUIThemesPalette } from '../themes/presets'
+import { NormalTypes } from '../utils/prop-types'
 
 export type SelectColor = {
   bg: string

--- a/components/snippet/styles.ts
+++ b/components/snippet/styles.ts
@@ -1,5 +1,5 @@
-import { SnippetTypes } from 'components/utils/prop-types'
-import { GeistUIThemesPalette } from 'components/themes/presets'
+import { SnippetTypes } from '../utils/prop-types'
+import { GeistUIThemesPalette } from '../themes/presets'
 
 export type SnippetStyles = {
   color: string

--- a/components/table/__tests__/index.test.tsx
+++ b/components/table/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import { Table, Code } from 'components'
-import { cellActions } from 'components/table/table-cell'
+import { TableCellActions } from '../table-cell'
 import { nativeEvent, updateWrapper } from 'tests/utils'
 import { act } from 'react-dom/test-utils'
 
@@ -100,7 +100,7 @@ describe('Table', () => {
   })
 
   it('should be possible to remove the row', () => {
-    const operation = (actions: cellActions) => {
+    const operation = (actions: TableCellActions) => {
       return <button onClick={() => actions.remove()}>Remove</button>
     }
     const data = [{ property: 'bold', description: 'boolean', operation }]
@@ -118,7 +118,7 @@ describe('Table', () => {
   })
 
   it('should be possible to update the row', () => {
-    const operation = (actions: cellActions) => {
+    const operation = (actions: TableCellActions) => {
       return (
         <button
           onClick={() =>

--- a/components/textarea/__tests__/index.test.tsx
+++ b/components/textarea/__tests__/index.test.tsx
@@ -13,7 +13,7 @@ describe('Textarea', () => {
   it('should work with different styles', () => {
     const wrapper = mount(
       <div>
-        <Textarea status="secondary" />
+        <Textarea type="secondary" />
         <Textarea width="20%" />
         <Textarea minHeight="100px" />
       </div>,

--- a/components/textarea/textarea.tsx
+++ b/components/textarea/textarea.tsx
@@ -11,7 +11,7 @@ interface Props {
   value?: string
   initialValue?: string
   placeholder?: string
-  status?: NormalTypes
+  type?: NormalTypes
   width?: string
   minHeight?: string
   disabled?: boolean
@@ -25,7 +25,7 @@ interface Props {
 
 const defaultProps = {
   initialValue: '',
-  status: 'default' as NormalTypes,
+  type: 'default' as NormalTypes,
   width: 'initial',
   minHeight: '6.25rem',
   disabled: false,
@@ -44,7 +44,7 @@ const Textarea = React.forwardRef<
   (
     {
       width,
-      status,
+      type,
       minHeight,
       disabled,
       readOnly,
@@ -67,8 +67,8 @@ const Textarea = React.forwardRef<
     const [selfValue, setSelfValue] = useState<string>(initialValue)
     const [hover, setHover] = useState<boolean>(false)
     const { color, borderColor, hoverBorder } = useMemo(
-      () => getColors(theme.palette, status),
-      [theme.palette, status],
+      () => getColors(theme.palette, type),
+      [theme.palette, type],
     )
 
     const changeHandler = (event: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/components/toggle/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/toggle/__tests__/__snapshots__/index.test.tsx.snap
@@ -367,3 +367,295 @@ exports[`Toggle should work with different sizes 1`] = `
         }
       </style></label></div>"
 `;
+
+exports[`Toggle should work with different status 1`] = `
+"<div><label class=\\"\\"><input type=\\"checkbox\\"><div class=\\"toggle  \\"><span class=\\"inner\\"></span></div><style>
+        label {
+          -webkit-tap-highlight-color: transparent;
+          display: inline-block;
+          vertical-align: middle;
+          white-space: nowrap;
+          user-select: none;
+          padding: 3px 0;
+          position: relative;
+          cursor: pointer;
+        }
+
+        input {
+          overflow: hidden;
+          visibility: hidden;
+          height: 0;
+          opacity: 0;
+          width: 0;
+          position: absolute;
+          background-color: transparent;
+          z-index: -1;
+        }
+
+        .toggle {
+          height: .875rem;
+          width: 1.75rem;
+          border-radius: .875rem;
+          transition-delay: 0.12s;
+          transition-duration: 0.2s;
+          transition-property: background, border;
+          transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+          position: relative;
+          border: 1px solid transparent;
+          background-color: #eaeaea;
+          padding: 0;
+        }
+
+        .inner {
+          width: calc(.875rem - 2px);
+          height: calc(.875rem - 2px);
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          left: 1px;
+          box-shadow: rgba(0, 0, 0, 0.2) 0 1px 2px 0, rgba(0, 0, 0, 0.1) 0 1px 3px 0;
+          transition: left 280ms cubic-bezier(0, 0, 0.2, 1);
+          border-radius: 50%;
+          background-color: #fff;
+        }
+
+        .disabled {
+          border-color: #eaeaea;
+          background-color: #fafafa;
+        }
+
+        .disabled > .inner {
+          background-color: #eaeaea;
+        }
+
+        .disabled.checked {
+          border-color: #888;
+          background-color: #888;
+        }
+
+        .checked {
+          background-color: #666;
+        }
+
+        .checked > .inner {
+          left: calc(100% - (.875rem - 2px));
+          box-shadow: none;
+        }
+      </style></label><label class=\\"\\"><input type=\\"checkbox\\"><div class=\\"toggle  \\"><span class=\\"inner\\"></span></div><style>
+        label {
+          -webkit-tap-highlight-color: transparent;
+          display: inline-block;
+          vertical-align: middle;
+          white-space: nowrap;
+          user-select: none;
+          padding: 3px 0;
+          position: relative;
+          cursor: pointer;
+        }
+
+        input {
+          overflow: hidden;
+          visibility: hidden;
+          height: 0;
+          opacity: 0;
+          width: 0;
+          position: absolute;
+          background-color: transparent;
+          z-index: -1;
+        }
+
+        .toggle {
+          height: .875rem;
+          width: 1.75rem;
+          border-radius: .875rem;
+          transition-delay: 0.12s;
+          transition-duration: 0.2s;
+          transition-property: background, border;
+          transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+          position: relative;
+          border: 1px solid transparent;
+          background-color: #eaeaea;
+          padding: 0;
+        }
+
+        .inner {
+          width: calc(.875rem - 2px);
+          height: calc(.875rem - 2px);
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          left: 1px;
+          box-shadow: rgba(0, 0, 0, 0.2) 0 1px 2px 0, rgba(0, 0, 0, 0.1) 0 1px 3px 0;
+          transition: left 280ms cubic-bezier(0, 0, 0.2, 1);
+          border-radius: 50%;
+          background-color: #fff;
+        }
+
+        .disabled {
+          border-color: #eaeaea;
+          background-color: #fafafa;
+        }
+
+        .disabled > .inner {
+          background-color: #eaeaea;
+        }
+
+        .disabled.checked {
+          border-color: #888;
+          background-color: #888;
+        }
+
+        .checked {
+          background-color: #0070f3;
+        }
+
+        .checked > .inner {
+          left: calc(100% - (.875rem - 2px));
+          box-shadow: none;
+        }
+      </style></label><label class=\\"\\"><input type=\\"checkbox\\"><div class=\\"toggle  \\"><span class=\\"inner\\"></span></div><style>
+        label {
+          -webkit-tap-highlight-color: transparent;
+          display: inline-block;
+          vertical-align: middle;
+          white-space: nowrap;
+          user-select: none;
+          padding: 3px 0;
+          position: relative;
+          cursor: pointer;
+        }
+
+        input {
+          overflow: hidden;
+          visibility: hidden;
+          height: 0;
+          opacity: 0;
+          width: 0;
+          position: absolute;
+          background-color: transparent;
+          z-index: -1;
+        }
+
+        .toggle {
+          height: .875rem;
+          width: 1.75rem;
+          border-radius: .875rem;
+          transition-delay: 0.12s;
+          transition-duration: 0.2s;
+          transition-property: background, border;
+          transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+          position: relative;
+          border: 1px solid transparent;
+          background-color: #eaeaea;
+          padding: 0;
+        }
+
+        .inner {
+          width: calc(.875rem - 2px);
+          height: calc(.875rem - 2px);
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          left: 1px;
+          box-shadow: rgba(0, 0, 0, 0.2) 0 1px 2px 0, rgba(0, 0, 0, 0.1) 0 1px 3px 0;
+          transition: left 280ms cubic-bezier(0, 0, 0.2, 1);
+          border-radius: 50%;
+          background-color: #fff;
+        }
+
+        .disabled {
+          border-color: #eaeaea;
+          background-color: #fafafa;
+        }
+
+        .disabled > .inner {
+          background-color: #eaeaea;
+        }
+
+        .disabled.checked {
+          border-color: #888;
+          background-color: #888;
+        }
+
+        .checked {
+          background-color: #f5a623;
+        }
+
+        .checked > .inner {
+          left: calc(100% - (.875rem - 2px));
+          box-shadow: none;
+        }
+      </style></label><label class=\\"\\"><input type=\\"checkbox\\"><div class=\\"toggle  \\"><span class=\\"inner\\"></span></div><style>
+        label {
+          -webkit-tap-highlight-color: transparent;
+          display: inline-block;
+          vertical-align: middle;
+          white-space: nowrap;
+          user-select: none;
+          padding: 3px 0;
+          position: relative;
+          cursor: pointer;
+        }
+
+        input {
+          overflow: hidden;
+          visibility: hidden;
+          height: 0;
+          opacity: 0;
+          width: 0;
+          position: absolute;
+          background-color: transparent;
+          z-index: -1;
+        }
+
+        .toggle {
+          height: .875rem;
+          width: 1.75rem;
+          border-radius: .875rem;
+          transition-delay: 0.12s;
+          transition-duration: 0.2s;
+          transition-property: background, border;
+          transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+          position: relative;
+          border: 1px solid transparent;
+          background-color: #eaeaea;
+          padding: 0;
+        }
+
+        .inner {
+          width: calc(.875rem - 2px);
+          height: calc(.875rem - 2px);
+          position: absolute;
+          top: 50%;
+          transform: translateY(-50%);
+          left: 1px;
+          box-shadow: rgba(0, 0, 0, 0.2) 0 1px 2px 0, rgba(0, 0, 0, 0.1) 0 1px 3px 0;
+          transition: left 280ms cubic-bezier(0, 0, 0.2, 1);
+          border-radius: 50%;
+          background-color: #fff;
+        }
+
+        .disabled {
+          border-color: #eaeaea;
+          background-color: #fafafa;
+        }
+
+        .disabled > .inner {
+          background-color: #eaeaea;
+        }
+
+        .disabled.checked {
+          border-color: #888;
+          background-color: #888;
+        }
+
+        .checked {
+          background-color: #e00;
+        }
+
+        .checked > .inner {
+          left: calc(100% - (.875rem - 2px));
+          box-shadow: none;
+        }
+      </style></label></div>"
+`;

--- a/components/toggle/__tests__/index.test.tsx
+++ b/components/toggle/__tests__/index.test.tsx
@@ -34,10 +34,10 @@ describe('Toggle', () => {
   it('should work with different status', () => {
     const wrapper = mount(
       <div>
-        <Toggle status="secondary" />
-        <Toggle status="success" />
-        <Toggle status="warning" />
-        <Toggle status="error" />
+        <Toggle type="secondary" />
+        <Toggle type="success" />
+        <Toggle type="warning" />
+        <Toggle type="error" />
       </div>,
     )
     expect(wrapper.html()).toMatchSnapshot()

--- a/components/toggle/__tests__/index.test.tsx
+++ b/components/toggle/__tests__/index.test.tsx
@@ -31,6 +31,18 @@ describe('Toggle', () => {
     expect(() => wrapper.unmount()).not.toThrow()
   })
 
+  it('should work with different status', () => {
+    const wrapper = mount(
+      <div>
+        <Toggle status="secondary" />
+        <Toggle status="success" />
+        <Toggle status="warning" />
+        <Toggle status="error" />
+      </div>,
+    )
+    expect(wrapper.html()).toMatchSnapshot()
+  })
+
   it('should set toggle follow checked prop', async () => {
     const wrapper = mount(<Toggle initialChecked={true} />)
     expectToggleIsChecked(wrapper)

--- a/components/toggle/styles.ts
+++ b/components/toggle/styles.ts
@@ -1,0 +1,32 @@
+import { GeistUIThemesPalette } from 'components/themes/presets'
+import { NormalTypes } from 'components/utils/prop-types'
+
+export type SelectColor = {
+  bg: string
+}
+
+export const getColors = (
+  palette: GeistUIThemesPalette,
+  status?: NormalTypes,
+): SelectColor => {
+  const colors: { [key in NormalTypes]: SelectColor } = {
+    default: {
+      bg: palette.success,
+    },
+    secondary: {
+      bg: palette.secondary,
+    },
+    success: {
+      bg: palette.success,
+    },
+    warning: {
+      bg: palette.warning,
+    },
+    error: {
+      bg: palette.error,
+    },
+  }
+
+  if (!status) return colors.default
+  return colors[status]
+}

--- a/components/toggle/styles.ts
+++ b/components/toggle/styles.ts
@@ -1,5 +1,5 @@
-import { GeistUIThemesPalette } from 'components/themes/presets'
-import { NormalTypes } from 'components/utils/prop-types'
+import { GeistUIThemesPalette } from '../themes/presets'
+import { NormalTypes } from '../utils/prop-types'
 
 export type SelectColor = {
   bg: string

--- a/components/toggle/toggle.tsx
+++ b/components/toggle/toggle.tsx
@@ -21,13 +21,13 @@ interface Props {
   onChange?: (ev: ToggleEvent) => void
   disabled?: boolean
   size?: NormalSizes
-  status?: NormalTypes
+  type?: NormalTypes
   className?: string
 }
 
 const defaultProps = {
   size: 'medium' as NormalSizes,
-  status: 'default' as NormalTypes,
+  type: 'default' as NormalTypes,
   disabled: false,
   initialChecked: false,
   className: '',
@@ -69,7 +69,7 @@ const Toggle: React.FC<ToggleProps> = ({
   disabled,
   onChange,
   size,
-  status,
+  type,
   className,
   ...props
 }) => {
@@ -95,7 +95,7 @@ const Toggle: React.FC<ToggleProps> = ({
     [disabled, selfChecked, onChange],
   )
 
-  const { bg } = useMemo(() => getColors(theme.palette, status), [theme.palette, status])
+  const { bg } = useMemo(() => getColors(theme.palette, type), [theme.palette, type])
 
   useEffect(() => {
     if (checked === undefined) return

--- a/components/toggle/toggle.tsx
+++ b/components/toggle/toggle.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import withDefaults from '../utils/with-defaults'
 import useTheme from '../use-theme'
-import { NormalSizes } from '../utils/prop-types'
+import { NormalSizes, NormalTypes } from '../utils/prop-types'
+import { getColors } from './styles'
 
 interface ToggleEventTarget {
   checked: boolean
@@ -20,11 +21,13 @@ interface Props {
   onChange?: (ev: ToggleEvent) => void
   disabled?: boolean
   size?: NormalSizes
+  status?: NormalTypes
   className?: string
 }
 
 const defaultProps = {
   size: 'medium' as NormalSizes,
+  status: 'default' as NormalTypes,
   disabled: false,
   initialChecked: false,
   className: '',
@@ -66,6 +69,7 @@ const Toggle: React.FC<ToggleProps> = ({
   disabled,
   onChange,
   size,
+  status,
   className,
   ...props
 }) => {
@@ -90,6 +94,8 @@ const Toggle: React.FC<ToggleProps> = ({
     },
     [disabled, selfChecked, onChange],
   )
+
+  const { bg } = useMemo(() => getColors(theme.palette, status), [theme.palette, status])
 
   useEffect(() => {
     if (checked === undefined) return
@@ -175,7 +181,7 @@ const Toggle: React.FC<ToggleProps> = ({
         }
 
         .checked {
-          background-color: ${theme.palette.success};
+          background-color: ${bg};
         }
 
         .checked > .inner {

--- a/components/tree/__tests__/index.test.tsx
+++ b/components/tree/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import { Tree } from 'components'
 import { nativeEvent } from 'tests/utils'
-import { FileTreeValue } from 'components/tree/tree'
+import { FileTreeValue } from '../tree'
 
 const mockFiles: Array<FileTreeValue> = [
   {

--- a/pages/en-us/components/auto-complete.mdx
+++ b/pages/en-us/components/auto-complete.mdx
@@ -27,6 +27,28 @@ AutoComplete control of input field.
 />
 
 <Playground
+  title="Type"
+  desc="Express state in different colors."
+  scope={{ AutoComplete, Spacer }}
+  code={`
+() => {
+  const options = [
+    { label: 'London', value: 'london' },
+    { label: 'Sydney', value: 'sydney' },
+    { label: 'Shanghai', value: 'shanghai' },
+  ]
+  return (<>
+    <AutoComplete type="success" placeholder="Enter here" options={options} />
+    <Spacer y={.5} />
+    <AutoComplete type="warning" placeholder="Enter here" options={options} />
+    <Spacer y={.5} />
+    <AutoComplete type="error" placeholder="Enter here" options={options} />
+  </>)
+}
+`}
+/>
+
+<Playground
   desc="Disable all."
   title="disabled"
   scope={{ AutoComplete }}
@@ -272,7 +294,7 @@ AutoComplete control of input field.
 | Attribute             | Description                               | Type                                             | Accepted values                                         | Default   |
 | --------------------- | ----------------------------------------- | ------------------------------------------------ | ------------------------------------------------------- | --------- |
 | **options**           | options of input                          | [AutoCompleteOptions](#type-autocompleteoptions) | -                                                       | -         |
-| **status**            | input type                                | `NormalTypes`                                    | `'default', 'secondary', 'success', 'warning', 'error'` | `default` |
+| **type**              | input type                                | `NormalTypes`                                    | `'default', 'secondary', 'success', 'warning', 'error'` | `default` |
 | **size**              | input size                                | `NormalSizes`                                    | `'mini', 'small', 'medium', 'large'`                    | `medium`  |
 | **initialValue**      | initial value                             | `string`                                         | -                                                       | -         |
 | **value**             | current value                             | `string`                                         | -                                                       | -         |

--- a/pages/en-us/components/checkbox.mdx
+++ b/pages/en-us/components/checkbox.mdx
@@ -36,18 +36,18 @@ Displays a boolean value.
 />
 
 <Playground
-  title="status"
+  title="Type"
   desc="Differentiate states by color."
   scope={{ Checkbox, Spacer }}
   code={`
 <>
-  <Checkbox checked={true} status="default">default</Checkbox>
+  <Checkbox checked={true} type="default">default</Checkbox>
   <Spacer y={.5} />
-  <Checkbox checked={true} status="success">success</Checkbox>
+  <Checkbox checked={true} type="success">success</Checkbox>
   <Spacer y={.5} />
-  <Checkbox checked={true} status="warning">warning</Checkbox>
+  <Checkbox checked={true} type="warning">warning</Checkbox>
   <Spacer y={.5} />
-  <Checkbox checked={true} status="error">error</Checkbox>
+  <Checkbox checked={true} type="error">error</Checkbox>
 </>
 `}
 />
@@ -88,17 +88,17 @@ Displays a boolean value.
 <Attributes edit="/pages/en-us/components/checkbox.mdx">
 <Attributes.Title>Checkbox.Props</Attributes.Title>
 
-| Attribute          | Description                                 | Type                                           | Accepted values                   | Default   |
-| ------------------ | ------------------------------------------- | ---------------------------------------------- | --------------------------------- | --------- |
-| **checked**        | checked or not                              | `boolean`                                      | -                                 | -         |
-| **initialChecked** | checked or not on initial                   | `boolean`                                      | -                                 | `false`   |
-| **onChange**       | change event handler                        | `CheckboxEvent`                                | -                                 | -         |
-| **value**          | unique identification value (only in group) | `string`                                       | -                                 | -         |
-| **disabled**       | disable checkbox                            | `boolean`                                      | -                                 | `false`   |
-| **size**           | checkbox size                               | `NormalSizes`                                  | [NormalSizes](#normalsizes)       | `small`   |
-| **status**         | current status                              | `NormalTypes`                                  | [CheckboxStatus](#checkboxstatus) | `default` |
-| **ref**            | forwardRef                                  | <Code>Ref<HTMLInputElement &#124; null></Code> | -                                 | -         |
-| ...                | native props                                | `LabelHTMLAttributes`                          | `'form', 'className', ...`        | -         |
+| Attribute          | Description                                 | Type                                           | Accepted values               | Default   |
+| ------------------ | ------------------------------------------- | ---------------------------------------------- | ----------------------------- | --------- |
+| **checked**        | checked or not                              | `boolean`                                      | -                             | -         |
+| **initialChecked** | checked or not on initial                   | `boolean`                                      | -                             | `false`   |
+| **onChange**       | change event handler                        | `CheckboxEvent`                                | -                             | -         |
+| **value**          | unique identification value (only in group) | `string`                                       | -                             | -         |
+| **disabled**       | disable checkbox                            | `boolean`                                      | -                             | `false`   |
+| **size**           | checkbox size                               | `NormalSizes`                                  | [NormalSizes](#normalsizes)   | `small`   |
+| **type**           | current type                                | `NormalTypes`                                  | [CheckboxType](#checkboxtype) | `default` |
+| **ref**            | forwardRef                                  | <Code>Ref<HTMLInputElement &#124; null></Code> | -                             | -         |
+| ...                | native props                                | `LabelHTMLAttributes`                          | `'form', 'className', ...`    | -         |
 
 <Attributes.Title>Checkbox.Group.Props</Attributes.Title>
 
@@ -116,10 +116,10 @@ Displays a boolean value.
 type NormalSizes = 'mini' | 'small' | 'medium' | 'large'
 ```
 
-<Attributes.Title>CheckboxStatus</Attributes.Title>
+<Attributes.Title>CheckboxType</Attributes.Title>
 
 ```ts
-type CheckboxStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
+type CheckboxType = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 <Attributes.Title>CheckboxEvent</Attributes.Title>

--- a/pages/en-us/components/checkbox.mdx
+++ b/pages/en-us/components/checkbox.mdx
@@ -36,6 +36,23 @@ Displays a boolean value.
 />
 
 <Playground
+  title="status"
+  desc="Differentiate states by color."
+  scope={{ Checkbox, Spacer }}
+  code={`
+<>
+  <Checkbox checked={true} status="default">default</Checkbox>
+  <Spacer y={.5} />
+  <Checkbox checked={true} status="success">success</Checkbox>
+  <Spacer y={.5} />
+  <Checkbox checked={true} status="warning">warning</Checkbox>
+  <Spacer y={.5} />
+  <Checkbox checked={true} status="error">error</Checkbox>
+</>
+`}
+/>
+
+<Playground
   title="disable"
   scope={{ Checkbox, Spacer }}
   code={`
@@ -71,15 +88,17 @@ Displays a boolean value.
 <Attributes edit="/pages/en-us/components/checkbox.mdx">
 <Attributes.Title>Checkbox.Props</Attributes.Title>
 
-| Attribute          | Description                                 | Type                  | Accepted values             | Default |
-| ------------------ | ------------------------------------------- | --------------------- | --------------------------- | ------- |
-| **checked**        | checked or not                              | `boolean`             | -                           | -       |
-| **initialChecked** | checked or not on initial                   | `boolean`             | -                           | `false` |
-| **onChange**       | change event handler                        | `CheckboxEvent`       | -                           | -       |
-| **value**          | unique identification value (only in group) | `string`              | -                           | -       |
-| **disabled**       | disable checkbox                            | `boolean`             | -                           | `false` |
-| **size**           | checkbox size                               | `NormalSizes`         | [NormalSizes](#normalsizes) | `small` |
-| ...                | native props                                | `LabelHTMLAttributes` | `'form', 'className', ...`  | -       |
+| Attribute          | Description                                 | Type                                           | Accepted values                   | Default   |
+| ------------------ | ------------------------------------------- | ---------------------------------------------- | --------------------------------- | --------- |
+| **checked**        | checked or not                              | `boolean`                                      | -                                 | -         |
+| **initialChecked** | checked or not on initial                   | `boolean`                                      | -                                 | `false`   |
+| **onChange**       | change event handler                        | `CheckboxEvent`                                | -                                 | -         |
+| **value**          | unique identification value (only in group) | `string`                                       | -                                 | -         |
+| **disabled**       | disable checkbox                            | `boolean`                                      | -                                 | `false`   |
+| **size**           | checkbox size                               | `NormalSizes`                                  | [NormalSizes](#normalsizes)       | `small`   |
+| **status**         | current status                              | `NormalTypes`                                  | [CheckboxStatus](#checkboxstatus) | `default` |
+| **ref**            | forwardRef                                  | <Code>Ref<HTMLInputElement &#124; null></Code> | -                                 | -         |
+| ...                | native props                                | `LabelHTMLAttributes`                          | `'form', 'className', ...`        | -         |
 
 <Attributes.Title>Checkbox.Group.Props</Attributes.Title>
 
@@ -95,6 +114,12 @@ Displays a boolean value.
 
 ```ts
 type NormalSizes = 'mini' | 'small' | 'medium' | 'large'
+```
+
+<Attributes.Title>CheckboxStatus</Attributes.Title>
+
+```ts
+type CheckboxStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 <Attributes.Title>CheckboxEvent</Attributes.Title>

--- a/pages/en-us/components/input.mdx
+++ b/pages/en-us/components/input.mdx
@@ -93,18 +93,18 @@ Retrieve text input from a user.
 />
 
 <Playground
-  title="status"
+  title="Type"
   desc="Differentiate states by color."
   scope={{ Input, Spacer }}
   code={`
 <>
-  <Input status="secondary" initialValue="The Evil Rabbit" />
+  <Input type="secondary" initialValue="The Evil Rabbit" />
   <Spacer y={.5} />
-  <Input status="success" initialValue="The Evil Rabbit" />
+  <Input type="success" initialValue="The Evil Rabbit" />
   <Spacer y={.5} />
-  <Input status="warning" initialValue="The Evil Rabbit" />
+  <Input type="warning" initialValue="The Evil Rabbit" />
   <Spacer y={.5} />
-  <Input status="error" initialValue="The Evil Rabbit" />
+  <Input type="error" initialValue="The Evil Rabbit" />
 </>
 `}
 />
@@ -216,7 +216,8 @@ Retrieve text input from a user.
 | **initialValue**  | initial value                 | `string`                                       | -                                 | -         |
 | **placeholder**   | placeholder                   | `string`                                       | -                                 | -         |
 | **size**          | input size                    | `NormalSizes`                                  | [InputSizes](#inputsizes)         | `medium`  |
-| **status**        | current status                | `NormalTypes`                                  | [InputStatus](#inputstatus)       | `default` |
+| **type**          | current type                  | `NormalTypes`                                  | [InputType](#inputtype)           | `default` |
+| **htmlType**      | native type attr              | `string`                                       | -                                 | `text`    |
 | **readOnly**      | native attr                   | `boolean`                                      | -                                 | `false`   |
 | **disabled**      | disable input                 | `boolean`                                      | -                                 | `false`   |
 | **clearable**     | show clear icon               | `boolean`                                      | -                                 | `false`   |
@@ -244,10 +245,10 @@ Retrieve text input from a user.
 type InputSizes = 'mini' | 'small' | 'medium' | 'large'
 ```
 
-<Attributes.Title>InputStatus</Attributes.Title>
+<Attributes.Title>InputType</Attributes.Title>
 
 ```ts
-type InputStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
+type InputType = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 <Attributes.Title>useInput</Attributes.Title>

--- a/pages/en-us/components/radio.mdx
+++ b/pages/en-us/components/radio.mdx
@@ -68,6 +68,23 @@ Provides single user input from a selection of options.
 />
 
 <Playground
+  title="status"
+  desc="Differentiate states by color."
+  scope={{ Radio, Spacer }}
+  code={`
+    <>
+      <Radio checked={false} status="default">default</Radio>
+      <Spacer y={.5} />
+      <Radio checked={false} status="success">success</Radio>
+      <Spacer y={.5} />
+      <Radio checked={false} status="warning">warning</Radio>
+      <Spacer y={.5} />
+      <Radio checked={false} status="error">error</Radio>
+    </>
+`}
+/>
+
+<Playground
   title="Description"
   desc="`Description` can be combined with other components."
   scope={{ Radio, Code }}
@@ -118,15 +135,17 @@ Provides single user input from a selection of options.
 <Attributes edit="/pages/en-us/components/radio.mdx">
 <Attributes.Title>Radio.Props</Attributes.Title>
 
-| Attribute    | Description                   | Type                      | Accepted values             | Default  |
-| ------------ | ----------------------------- | ------------------------- | --------------------------- | -------- |
-| **checked**  | selected or not (in single)   | `boolean`                 | -                           | `false`  |
-| **value**    | unique ident value (in group) | `string`                  | -                           | -        |
-| **id**       | native attr                   | `string`                  | -                           | -        |
-| **disabled** | disable current radio         | `boolean`                 | -                           | `false`  |
-| **size**     | radio size                    | `NormalSizes`             | [NormalSizes](#normalsizes) | `medium` |
-| **onChange** | change event                  | `(e: RadioEvent) => void` | -                           | -        |
-| ...          | native props                  | `InputHTMLAttributes`     | `'id', 'className', ...`    | -        |
+| Attribute    | Description                   | Type                                           | Accepted values             | Default   |
+| ------------ | ----------------------------- | ---------------------------------------------- | --------------------------- | --------- |
+| **checked**  | selected or not (in single)   | `boolean`                                      | -                           | `false`   |
+| **value**    | unique ident value (in group) | `string`                                       | -                           | -         |
+| **id**       | native attr                   | `string`                                       | -                           | -         |
+| **disabled** | disable current radio         | `boolean`                                      | -                           | `false`   |
+| **size**     | radio size                    | `NormalSizes`                                  | [NormalSizes](#normalsizes) | `medium`  |
+| **status**   | current status                | `NormalTypes`                                  | [RadioStatus](#radiostatus) | `default` |
+| **onChange** | change event                  | `(e: RadioEvent) => void`                      | -                           | -         |
+| **ref**      | forwardRef                    | <Code>Ref<HTMLInputElement &#124; null></Code> | -                           | -         |
+| ...          | native props                  | `InputHTMLAttributes`                          | `'id', 'className', ...`    | -         |
 
 <Attributes.Title>Radio.Group.Props</Attributes.Title>
 
@@ -150,6 +169,12 @@ Provides single user input from a selection of options.
 
 ```ts
 type NormalSizes = 'mini' | 'small' | 'medium' | 'large'
+```
+
+<Attributes.Title>RadioStatus</Attributes.Title>
+
+```ts
+type RadioStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>

--- a/pages/en-us/components/radio.mdx
+++ b/pages/en-us/components/radio.mdx
@@ -68,18 +68,18 @@ Provides single user input from a selection of options.
 />
 
 <Playground
-  title="status"
+  title="Type"
   desc="Differentiate states by color."
   scope={{ Radio, Spacer }}
   code={`
     <>
-      <Radio checked={false} status="default">default</Radio>
+      <Radio checked={false} type="default">default</Radio>
       <Spacer y={.5} />
-      <Radio checked={false} status="success">success</Radio>
+      <Radio checked={false} type="success">success</Radio>
       <Spacer y={.5} />
-      <Radio checked={false} status="warning">warning</Radio>
+      <Radio checked={false} type="warning">warning</Radio>
       <Spacer y={.5} />
-      <Radio checked={false} status="error">error</Radio>
+      <Radio checked={false} type="error">error</Radio>
     </>
 `}
 />
@@ -142,7 +142,7 @@ Provides single user input from a selection of options.
 | **id**       | native attr                   | `string`                                       | -                           | -         |
 | **disabled** | disable current radio         | `boolean`                                      | -                           | `false`   |
 | **size**     | radio size                    | `NormalSizes`                                  | [NormalSizes](#normalsizes) | `medium`  |
-| **status**   | current status                | `NormalTypes`                                  | [RadioStatus](#radiostatus) | `default` |
+| **type**     | current type                  | `NormalTypes`                                  | [RadioType](#radiotype)     | `default` |
 | **onChange** | change event                  | `(e: RadioEvent) => void`                      | -                           | -         |
 | **ref**      | forwardRef                    | <Code>Ref<HTMLInputElement &#124; null></Code> | -                           | -         |
 | ...          | native props                  | `InputHTMLAttributes`                          | `'id', 'className', ...`    | -         |
@@ -171,10 +171,10 @@ Provides single user input from a selection of options.
 type NormalSizes = 'mini' | 'small' | 'medium' | 'large'
 ```
 
-<Attributes.Title>RadioStatus</Attributes.Title>
+<Attributes.Title>RadioType</Attributes.Title>
 
 ```ts
-type RadioStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
+type RadioType = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>

--- a/pages/en-us/components/select.mdx
+++ b/pages/en-us/components/select.mdx
@@ -27,33 +27,33 @@ Display a dropdown list of items.
 />
 
 <Playground
-  title="status"
+  title="Type"
   desc="Differentiate states by color."
   scope={{ Select, Spacer }}
   code={`
-() => {
+() => (
   <>
-    <Select placeholder="default" status="default">
+    <Select placeholder="default" type="default">
       <Select.Option value="1">Option 1</Select.Option>
       <Select.Option value="2">Option 2</Select.Option>
     </Select>
     <Spacer y={.5} />
-    <Select placeholder="success" status="success">
+    <Select placeholder="success" type="success">
       <Select.Option value="1">Option 1</Select.Option>
       <Select.Option value="2">Option 2</Select.Option>
     </Select>
     <Spacer y={.5} />
-    <Select placeholder="warning" status="warning">
+    <Select placeholder="warning" type="warning">
       <Select.Option value="1">Option 1</Select.Option>
       <Select.Option value="2">Option 2</Select.Option>
     </Select>
     <Spacer y={.5} />
-    <Select placeholder="error" status="error">
+    <Select placeholder="error" type="error">
       <Select.Option value="1">Option 1</Select.Option>
       <Select.Option value="2">Option 2</Select.Option>
     </Select>
   </>
-}
+)
 `}
 />
 
@@ -232,7 +232,7 @@ Display a dropdown list of items.
 | **placeholder**       | placeholder string                                       | `string`                                            | -                                 | -               |
 | **width**             | css width value of select                                | `string`                                            | -                                 | `initial`       |
 | **size**              | select component size                                    | `NormalSizes`                                       | [NormalSizes](#normalsizes)       | `medium`        |
-| **status**            | current status                                           | `NormalTypes`                                       | [SelectStatus](#selectstatus)     | `default`       |
+| **type**              | current type                                             | `NormalTypes`                                       | [SelectType](#selecttype)         | `default`       |
 | **icon**              | icon component                                           | `ComponentType`                                     | -                                 | `SVG Component` |
 | **pure**              | remove icon component                                    | `boolean`                                           | -                                 | `false`         |
 | **multiple**          | support multiple selection                               | `boolean`                                           | -                                 | `false`         |
@@ -259,10 +259,10 @@ Display a dropdown list of items.
 type NormalSizes = 'mini' | 'small' | 'medium' | 'large'
 ```
 
-<Attributes.Title>SelectStatus</Attributes.Title>
+<Attributes.Title>SelectType</Attributes.Title>
 
 ```ts
-type SelectStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
+type SelectType = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>

--- a/pages/en-us/components/select.mdx
+++ b/pages/en-us/components/select.mdx
@@ -27,6 +27,37 @@ Display a dropdown list of items.
 />
 
 <Playground
+  title="status"
+  desc="Differentiate states by color."
+  scope={{ Select, Spacer }}
+  code={`
+() => {
+  <>
+    <Select placeholder="default" status="default">
+      <Select.Option value="1">Option 1</Select.Option>
+      <Select.Option value="2">Option 2</Select.Option>
+    </Select>
+    <Spacer y={.5} />
+    <Select placeholder="success" status="success">
+      <Select.Option value="1">Option 1</Select.Option>
+      <Select.Option value="2">Option 2</Select.Option>
+    </Select>
+    <Spacer y={.5} />
+    <Select placeholder="warning" status="warning">
+      <Select.Option value="1">Option 1</Select.Option>
+      <Select.Option value="2">Option 2</Select.Option>
+    </Select>
+    <Spacer y={.5} />
+    <Select placeholder="error" status="error">
+      <Select.Option value="1">Option 1</Select.Option>
+      <Select.Option value="2">Option 2</Select.Option>
+    </Select>
+  </>
+}
+`}
+/>
+
+<Playground
   title="Disabled"
   desc="Disable all options."
   scope={{ Select }}
@@ -201,6 +232,7 @@ Display a dropdown list of items.
 | **placeholder**       | placeholder string                                       | `string`                                            | -                                 | -               |
 | **width**             | css width value of select                                | `string`                                            | -                                 | `initial`       |
 | **size**              | select component size                                    | `NormalSizes`                                       | [NormalSizes](#normalsizes)       | `medium`        |
+| **status**            | current status                                           | `NormalTypes`                                       | [SelectStatus](#selectstatus)     | `default`       |
 | **icon**              | icon component                                           | `ComponentType`                                     | -                                 | `SVG Component` |
 | **pure**              | remove icon component                                    | `boolean`                                           | -                                 | `false`         |
 | **multiple**          | support multiple selection                               | `boolean`                                           | -                                 | `false`         |
@@ -225,6 +257,12 @@ Display a dropdown list of items.
 
 ```ts
 type NormalSizes = 'mini' | 'small' | 'medium' | 'large'
+```
+
+<Attributes.Title>SelectStatus</Attributes.Title>
+
+```ts
+type SelectStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>

--- a/pages/en-us/components/slider.mdx
+++ b/pages/en-us/components/slider.mdx
@@ -20,18 +20,18 @@ Display the current value and an inputable range.
 />
 
 <Playground
-  title="status"
+  title="Type"
   desc="Differentiate states by color."
   scope={{ Slider, Spacer }}
   code={`
     <>
-      <Slider status="default" initialValue={20} />
+      <Slider type="default" initialValue={20} />
       <Spacer />
-      <Slider status="success" initialValue={20} />
+      <Slider type="success" initialValue={20} />
       <Spacer />
-      <Slider status="warning" initialValue={20} />
+      <Slider type="warning" initialValue={20} />
       <Spacer />
-      <Slider status="error" initialValue={20} />
+      <Slider type="error" initialValue={20} />
     </>
 `}
 />
@@ -96,7 +96,7 @@ Display the current value and an inputable range.
 | ---------------- | -------------------------------------------------- | ----------------------- | -------------------------------- | --------- |
 | **initialValue** | initial value                                      | `number`                | -                                | 0         |
 | **value**        | slider value                                       | `number`                | -                                | 0         |
-| **status**       | current status                                     | `NormalTypes`           | [SliderStatus](#sliderstatus)    | `default` |
+| **type**         | current type                                       | `NormalTypes`           | [SliderType](#slidertype)        | `default` |
 | **step**         | the granularity the slider can step through values | `number`                | -                                | 1         |
 | **max**          | the maximum value of slider                        | `number`                | -                                | 100       |
 | **min**          | the minimum value of slider                        | `number`                | -                                | 0         |
@@ -106,10 +106,10 @@ Display the current value and an inputable range.
 | **onChange**     | called when the value of silder changes            | `(val: number) => void` | -                                | -         |
 | ...              | native props                                       | `HTMLAttributes`        | `'id', 'name', 'className', ...` | -         |
 
-<Attributes.Title>SliderStatus</Attributes.Title>
+<Attributes.Title>SliderType</Attributes.Title>
 
 ```ts
-type SliderStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
+type SliderType = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>

--- a/pages/en-us/components/slider.mdx
+++ b/pages/en-us/components/slider.mdx
@@ -20,6 +20,23 @@ Display the current value and an inputable range.
 />
 
 <Playground
+  title="status"
+  desc="Differentiate states by color."
+  scope={{ Slider, Spacer }}
+  code={`
+    <>
+      <Slider status="default" initialValue={20} />
+      <Spacer />
+      <Slider status="success" initialValue={20} />
+      <Spacer />
+      <Slider status="warning" initialValue={20} />
+      <Spacer />
+      <Slider status="error" initialValue={20} />
+    </>
+`}
+/>
+
+<Playground
   title="Disabled"
   desc="Do not respond to drag and click."
   scope={{ Slider }}
@@ -75,18 +92,25 @@ Display the current value and an inputable range.
 <Attributes edit="/pages/en-us/components/slider.mdx">
 <Attributes.Title>Slider.Props</Attributes.Title>
 
-| Attribute        | Description                                        | Type                    | Accepted values                  | Default |
-| ---------------- | -------------------------------------------------- | ----------------------- | -------------------------------- | ------- |
-| **initialValue** | initial value                                      | `number`                | -                                | 0       |
-| **value**        | slider value                                       | `number`                | -                                | 0       |
-| **step**         | the granularity the slider can step through values | `number`                | -                                | 1       |
-| **max**          | the maximum value of slider                        | `number`                | -                                | 100     |
-| **min**          | the minimum value of slider                        | `number`                | -                                | 0       |
+| Attribute        | Description                                        | Type                    | Accepted values                  | Default   |
+| ---------------- | -------------------------------------------------- | ----------------------- | -------------------------------- | --------- |
+| **initialValue** | initial value                                      | `number`                | -                                | 0         |
+| **value**        | slider value                                       | `number`                | -                                | 0         |
+| **status**       | current status                                     | `NormalTypes`           | [SliderStatus](#sliderstatus)    | `default` |
+| **step**         | the granularity the slider can step through values | `number`                | -                                | 1         |
+| **max**          | the maximum value of slider                        | `number`                | -                                | 100       |
+| **min**          | the minimum value of slider                        | `number`                | -                                | 0         |
 | **disabled**     | disable slider interaction                         | `boolean`               | `false`                          |
-| **showMarkers**  | show each marker                                   | `boolean`               | -                                | `false` |
-| **hideValue**    | hide slider value                                  | `boolean`               | -                                | `false` |
-| **onChange**     | called when the value of silder changes            | `(val: number) => void` | -                                | -       |
-| ...              | native props                                       | `HTMLAttributes`        | `'id', 'name', 'className', ...` | -       |
+| **showMarkers**  | show each marker                                   | `boolean`               | -                                | `false`   |
+| **hideValue**    | hide slider value                                  | `boolean`               | -                                | `false`   |
+| **onChange**     | called when the value of silder changes            | `(val: number) => void` | -                                | -         |
+| ...              | native props                                       | `HTMLAttributes`        | `'id', 'name', 'className', ...` | -         |
+
+<Attributes.Title>SliderStatus</Attributes.Title>
+
+```ts
+type SliderStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
+```
 
 </Attributes>
 

--- a/pages/en-us/components/textarea.mdx
+++ b/pages/en-us/components/textarea.mdx
@@ -38,18 +38,18 @@ Retrieve multi-line user input.
 />
 
 <Playground
-  title="status"
+  title="Type"
   desc="Differentiate states by color."
   scope={{ Textarea, Spacer }}
   code={`
 <>
-  <Textarea status="success" minHeight="65px" value="Success" />
+  <Textarea type="success" minHeight="65px" value="Success" />
   <Spacer x={.5} inline />
-  <Textarea status="secondary" minHeight="65px" value="Secondary" />
+  <Textarea type="secondary" minHeight="65px" value="Secondary" />
   <Spacer y={.5} />
-  <Textarea status="warning" minHeight="65px" value="Warning" />
+  <Textarea type="warning" minHeight="65px" value="Warning" />
   <Spacer x={.5} inline />
-  <Textarea status="error" minHeight="65px" value="Error" />
+  <Textarea type="error" minHeight="65px" value="Error" />
 </>
 `}
 />
@@ -129,7 +129,7 @@ Retrieve multi-line user input.
 | **value**        | textarea value        | `string`                         | -                                                                | -         |
 | **initialValue** | textarea value        | `string`                         | -                                                                | -         |
 | **placeholder**  | placeholder           | `string`                         | -                                                                | -         |
-| **status**       | current status        | `NormalTypes`                    | `'default', 'secondary', 'success', 'warning', 'error'`          | `default` |
+| **type**         | current type          | `NormalTypes`                    | [TextareaType](#textareatype)                                    | `default` |
 | **readOnly**     | native attr           | `boolean`                        | -                                                                | `false`   |
 | **disabled**     | disable input         | `boolean`                        | -                                                                | `false`   |
 | **width**        | set width string      | `string`                         | -                                                                | `initial` |
@@ -153,6 +153,12 @@ type useInput = (
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   }
 }
+```
+
+<Attributes.Title>TextareaType</Attributes.Title>
+
+```ts
+type TextareaType = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>

--- a/pages/en-us/components/toggle.mdx
+++ b/pages/en-us/components/toggle.mdx
@@ -22,6 +22,25 @@ Displays a boolean value.
 />
 
 <Playground
+  title="Status"
+  desc="Differentiate states by color."
+  scope={{ Toggle, Spacer }}
+  code={`
+<>
+  <Toggle status="default" initialChecked />
+  <Spacer y={.5} />
+  <Toggle status="secondary" initialChecked />
+  <Spacer y={.5} />
+  <Toggle status="success" initialChecked />
+  <Spacer y={.5} />
+  <Toggle status="warning" initialChecked />
+  <Spacer y={.5} />
+  <Toggle status="error" initialChecked />
+</>
+`}
+/>
+
+<Playground
   title="disabled"
   scope={{ Toggle, Spacer }}
   code={`
@@ -64,14 +83,15 @@ Displays a boolean value.
 <Attributes edit="/pages/en-us/components/toggle.mdx">
 <Attributes.Title>Toggle.Props</Attributes.Title>
 
-| Attribute          | Description               | Type                  | Accepted values                      | Default  |
-| ------------------ | ------------------------- | --------------------- | ------------------------------------ | -------- |
-| **checked**        | checked or not            | `boolean`             | -                                    | -        |
-| **initialChecked** | checked or not on initial | `boolean`             | -                                    | `false`  |
-| **onChange**       | change event handler      | `ToggleEvent`         | -                                    | -        |
-| **size**           | input size                | `NormalSizes`         | `'mini', 'small', 'medium', 'large'` | `medium` |
-| **disabled**       | disable toggle            | `boolean`             | -                                    | `false`  |
-| ...                | native props              | `LabelHTMLAttributes` | `'from', 'name', 'className', ...`   | -        |
+| Attribute          | Description               | Type                  | Accepted values                      | Default   |
+| ------------------ | ------------------------- | --------------------- | ------------------------------------ | --------- |
+| **checked**        | checked or not            | `boolean`             | -                                    | -         |
+| **initialChecked** | checked or not on initial | `boolean`             | -                                    | `false`   |
+| **onChange**       | change event handler      | `ToggleEvent`         | -                                    | -         |
+| **size**           | input size                | `NormalSizes`         | `'mini', 'small', 'medium', 'large'` | `medium`  |
+| **status**         | current status            | `NormalTypes`         | [ToggleStatus](#togglestatus)        | `default` |
+| **disabled**       | disable toggle            | `boolean`             | -                                    | `false`   |
+| ...                | native props              | `LabelHTMLAttributes` | `'from', 'name', 'className', ...`   | -         |
 
 <Attributes.Title>ToggleEvent</Attributes.Title>
 
@@ -86,6 +106,12 @@ export interface ToggleEvent {
   preventDefault: () => void
   nativeEvent: React.ChangeEvent
 }
+```
+
+<Attributes.Title>ToggleStatus</Attributes.Title>
+
+```ts
+type ToggleStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>

--- a/pages/en-us/components/toggle.mdx
+++ b/pages/en-us/components/toggle.mdx
@@ -22,20 +22,20 @@ Displays a boolean value.
 />
 
 <Playground
-  title="Status"
+  title="Type"
   desc="Differentiate states by color."
   scope={{ Toggle, Spacer }}
   code={`
 <>
-  <Toggle status="default" initialChecked />
+  <Toggle type="default" initialChecked />
   <Spacer y={.5} />
-  <Toggle status="secondary" initialChecked />
+  <Toggle type="secondary" initialChecked />
   <Spacer y={.5} />
-  <Toggle status="success" initialChecked />
+  <Toggle type="success" initialChecked />
   <Spacer y={.5} />
-  <Toggle status="warning" initialChecked />
+  <Toggle type="warning" initialChecked />
   <Spacer y={.5} />
-  <Toggle status="error" initialChecked />
+  <Toggle type="error" initialChecked />
 </>
 `}
 />
@@ -89,7 +89,7 @@ Displays a boolean value.
 | **initialChecked** | checked or not on initial | `boolean`             | -                                    | `false`   |
 | **onChange**       | change event handler      | `ToggleEvent`         | -                                    | -         |
 | **size**           | input size                | `NormalSizes`         | `'mini', 'small', 'medium', 'large'` | `medium`  |
-| **status**         | current status            | `NormalTypes`         | [ToggleStatus](#togglestatus)        | `default` |
+| **type**           | current type              | `NormalTypes`         | [ToggleType](#toggletype)            | `default` |
 | **disabled**       | disable toggle            | `boolean`             | -                                    | `false`   |
 | ...                | native props              | `LabelHTMLAttributes` | `'from', 'name', 'className', ...`   | -         |
 
@@ -108,10 +108,10 @@ export interface ToggleEvent {
 }
 ```
 
-<Attributes.Title>ToggleStatus</Attributes.Title>
+<Attributes.Title>ToggleType</Attributes.Title>
 
 ```ts
-type ToggleStatus = 'default' | 'secondary' | 'success' | 'warning' | 'error'
+type ToggleType = 'default' | 'secondary' | 'success' | 'warning' | 'error'
 ```
 
 </Attributes>


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

To make components more consistents, added the `status` prop who allows to show the component with different colors based in a status.
components affected: `checkbox`, `radio`, `select`, `slider` and `toggle`

Will solve https://github.com/geist-org/react/issues/507