### PR TITLE
fix: deprecated pseudo element selector

### DIFF
--- a/components/css-baseline/__tests__/__snapshots__/baseline.test.tsx.snap
+++ b/components/css-baseline/__tests__/__snapshots__/baseline.test.tsx.snap
@@ -256,7 +256,7 @@ initialize {
           outline: none;
         }
 
-        summary::-webkit-details-marker,
+        summary::marker,
         summary::before {
           display: none;
         }
@@ -583,7 +583,7 @@ initialize {
           outline: none;
         }
 
-        summary::-webkit-details-marker,
+        summary::marker,
         summary::before {
           display: none;
         }

--- a/components/css-baseline/css-baseline.tsx
+++ b/components/css-baseline/css-baseline.tsx
@@ -259,7 +259,7 @@ const CssBaseline: React.FC<React.PropsWithChildren<unknown>> = ({ children }) =
           outline: none;
         }
 
-        summary::-webkit-details-marker,
+        summary::marker,
         summary::before {
           display: none;
         }


### PR DESCRIPTION
## Change information

- [x] Updated Snapshot

<img width="562" alt="Screenshot 2021-05-29 at 4 39 54 PM" src="https://user-images.githubusercontent.com/61158210/120068079-809aec80-c09c-11eb-9c6d-cf10f4c01022.png">

Would Boost Light House Scores 🚀


