### PR TITLE
feat: close modal from backdrop without check hasActions

### DIFF
--- a/components/modal/__tests__/index.test.tsx
+++ b/components/modal/__tests__/index.test.tsx
@@ -63,19 +63,6 @@ describe('Modal', () => {
     expect(closeHandler).not.toHaveBeenCalled()
   })
 
-  it('should ignore backdrop disabled when actions missing', async () => {
-    const closeHandler = jest.fn()
-    const wrapper = mount(
-      <Modal open={true} disableBackdropClick onClose={closeHandler}>
-        <Modal.Title>Modal</Modal.Title>
-      </Modal>,
-    )
-    wrapper.find('.backdrop').simulate('click', nativeEvent)
-    await updateWrapper(wrapper, 500)
-    expectModalIsClosed(wrapper)
-    expect(closeHandler).toHaveBeenCalled()
-  })
-
   it('should ignore event when action disabled', () => {
     const actions1 = jest.fn()
     const actions2 = jest.fn()

--- a/components/modal/modal.tsx
+++ b/components/modal/modal.tsx
@@ -66,7 +66,7 @@ const Modal: React.FC<React.PropsWithChildren<ModalProps>> = ({
   }, [open])
 
   const closeFromBackdrop = () => {
-    if (disableBackdropClick && hasActions) return
+    if (disableBackdropClick) return
     closeModal()
   }
 


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

If users set disableBackdropClick as false, they just want to prevent it without check the amount of action component.

