### PR TITLE
fix: summary tag for safari

### DIFF
--- a/components/css-baseline/__tests__/__snapshots__/baseline.test.tsx.snap
+++ b/components/css-baseline/__tests__/__snapshots__/baseline.test.tsx.snap
@@ -248,6 +248,14 @@ initialize {
         details:active {
           outline: none;
         }
+        
+        details &gt; summary {
+          list-style: none;
+        }
+        
+        details &gt; summary::-webkit-details-marker {
+          display: none;
+        }
 
         summary {
           cursor: pointer;
@@ -271,6 +279,8 @@ initialize {
           outline: none;
           list-style: none;
         }
+        
+        
 
         blockquote {
           padding: calc(0.667 * 16pt) 16pt;
@@ -575,6 +585,14 @@ initialize {
         details:active {
           outline: none;
         }
+        
+        details &gt; summary {
+          list-style: none;
+        }
+        
+        details &gt; summary::-webkit-details-marker {
+          display: none;
+        }
 
         summary {
           cursor: pointer;
@@ -598,6 +616,8 @@ initialize {
           outline: none;
           list-style: none;
         }
+        
+        
 
         blockquote {
           padding: calc(0.667 * 16pt) 16pt;

--- a/components/css-baseline/css-baseline.tsx
+++ b/components/css-baseline/css-baseline.tsx
@@ -251,6 +251,14 @@ const CssBaseline: React.FC<React.PropsWithChildren<unknown>> = ({ children }) =
         details:active {
           outline: none;
         }
+        
+        details > summary {
+          list-style: none;
+        }
+        
+        details > summary::-webkit-details-marker {
+          display: none;
+        }
 
         summary {
           cursor: pointer;
@@ -274,6 +282,8 @@ const CssBaseline: React.FC<React.PropsWithChildren<unknown>> = ({ children }) =
           outline: none;
           list-style: none;
         }
+        
+        
 
         blockquote {
           padding: calc(0.667 * ${theme.layout.gap}) ${theme.layout.gap};


### PR DESCRIPTION
## Change information



Fixes Summary Detail Default icon for Safari

Before: 

<img width="254" alt="Screenshot 2021-06-24 at 8 54 08 AM" src="https://user-images.githubusercontent.com/61158210/123197819-be3b3b80-d4c9-11eb-980d-eb14ad266d01.png">


After:

<img width="218" alt="Screenshot 2021-06-24 at 8 55 04 AM" src="https://user-images.githubusercontent.com/61158210/123197918-e1fe8180-d4c9-11eb-9c65-6d83155cc909.png">
