### PR TITLE
feat(select): imporve the focus events to export simulated ref

### DIFF
--- a/components/select/__tests__/__snapshots__/index.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/index.test.tsx.snap
@@ -1,7 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select should render correctly 1`] = `
-"<div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+"<div><div class=\\"select   \\"><input type=\\"search\\" role=\\"combobox\\" aria-haspopup=\\"listbox\\" readonly=\\"\\" unselectable=\\"on\\" aria-expanded=\\"false\\"><style>
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        </style><span class=\\"value placeholder\\"><span><style>
         span {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -18,86 +31,101 @@ exports[`Select should render correctly 1`] = `
           height: 1.214em;
         }
       </style></svg></div><style>
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
+
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: #999;
+            }
+
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          </style></div><div class=\\"select   \\" scale=\\"2\\"><input type=\\"search\\" role=\\"combobox\\" aria-haspopup=\\"listbox\\" readonly=\\"\\" unselectable=\\"on\\" aria-expanded=\\"false\\"><style>
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
             padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
+            font-size: 0;
+            border: none;
           }
-
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
-
-          .placeholder {
-            color: #999;
-          }
-
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        </style></div><div class=\\"select  \\" scale=\\"2\\"><span class=\\"value placeholder\\"><span><style>
+        </style><span class=\\"value placeholder\\"><span><style>
         span {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -114,90 +142,105 @@ exports[`Select should render correctly 1`] = `
           height: 1.214em;
         }
       </style></svg></div><style>
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(1.3125 * 16px);
-            --select-height: calc(3.375 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.501 * 16px) 0
-              calc(1.0005000000000002 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(1.3125 * 16px);
+              --select-height: calc(3.375 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.501 * 16px) 0
+                calc(1.0005000000000002 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.501 * 16px) calc(0.501 * 16px) calc(0.501 * 16px)
-              calc(1.0005000000000002 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.501 * 16px) calc(0.501 * 16px) calc(0.501 * 16px)
+                calc(1.0005000000000002 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #999;
-          }
+            .placeholder {
+              color: #999;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        </style></div></div>"
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          </style></div></div>"
 `;
 
 exports[`Select should work correctly with labels 1`] = `
-"<div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+"<div class=\\"select   \\"><input type=\\"search\\" role=\\"combobox\\" aria-haspopup=\\"listbox\\" readonly=\\"\\" unselectable=\\"on\\" aria-expanded=\\"false\\"><style>
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        </style><span class=\\"value placeholder\\"><span><style>
         span {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -214,95 +257,547 @@ exports[`Select should work correctly with labels 1`] = `
           height: 1.214em;
         }
       </style></svg></div><style>
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #999;
-          }
+            .placeholder {
+              color: #999;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        </style></div>"
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          </style></div>"
 `;
 
 exports[`Select should work with different icons 1`] = `
 initialize {
   "0": Node {
     "attribs": Object {
-      "class": "select  ",
+      "class": "select   ",
     },
     "children": Array [
+      Node {
+        "attribs": Object {
+          "aria-expanded": "false",
+          "aria-haspopup": "listbox",
+          "readonly": "",
+          "role": "combobox",
+          "type": "search",
+          "unselectable": "on",
+        },
+        "children": Array [],
+        "name": "input",
+        "namespace": "http://www.w3.org/1999/xhtml",
+        "next": Node {
+          "attribs": Object {},
+          "children": Array [
+            Node {
+              "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "text",
+            },
+          ],
+          "name": "style",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": Node {
+            "attribs": Object {
+              "class": "value placeholder",
+            },
+            "children": Array [
+              Node {
+                "attribs": Object {},
+                "children": Array [
+                  Node {
+                    "attribs": Object {},
+                    "children": Array [
+                      Node {
+                        "data": "
+        span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          line-height: var(--select-height);
+          min-width: 0;
+        }
+      ",
+                        "next": null,
+                        "parent": [Circular],
+                        "prev": null,
+                        "type": "text",
+                      },
+                    ],
+                    "name": "style",
+                    "namespace": "http://www.w3.org/1999/xhtml",
+                    "next": null,
+                    "parent": [Circular],
+                    "prev": null,
+                    "type": "style",
+                    "x-attribsNamespace": Object {},
+                    "x-attribsPrefix": Object {},
+                  },
+                ],
+                "name": "span",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "next": null,
+                "parent": [Circular],
+                "prev": null,
+                "type": "tag",
+                "x-attribsNamespace": Object {},
+                "x-attribsPrefix": Object {},
+              },
+            ],
+            "name": "span",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": Node {
+              "attribs": Object {},
+              "children": Array [
+                Node {
+                  "data": "
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
+
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
+
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
+
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
+
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
+
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
+
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: #999;
+            }
+
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
+                  "next": null,
+                  "parent": [Circular],
+                  "prev": null,
+                  "type": "text",
+                },
+              ],
+              "name": "style",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "next": null,
+              "parent": [Circular],
+              "prev": [Circular],
+              "type": "style",
+              "x-attribsNamespace": Object {},
+              "x-attribsPrefix": Object {},
+            },
+            "parent": [Circular],
+            "prev": [Circular],
+            "type": "tag",
+            "x-attribsNamespace": Object {
+              "class": undefined,
+            },
+            "x-attribsPrefix": Object {
+              "class": undefined,
+            },
+          },
+          "parent": [Circular],
+          "prev": [Circular],
+          "type": "style",
+          "x-attribsNamespace": Object {},
+          "x-attribsPrefix": Object {},
+        },
+        "parent": [Circular],
+        "prev": null,
+        "type": "tag",
+        "x-attribsNamespace": Object {
+          "aria-expanded": undefined,
+          "aria-haspopup": undefined,
+          "readonly": undefined,
+          "role": undefined,
+          "type": undefined,
+          "unselectable": undefined,
+        },
+        "x-attribsPrefix": Object {
+          "aria-expanded": undefined,
+          "aria-haspopup": undefined,
+          "readonly": undefined,
+          "role": undefined,
+          "type": undefined,
+          "unselectable": undefined,
+        },
+      },
+      Node {
+        "attribs": Object {},
+        "children": Array [
+          Node {
+            "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+            "next": null,
+            "parent": [Circular],
+            "prev": null,
+            "type": "text",
+          },
+        ],
+        "name": "style",
+        "namespace": "http://www.w3.org/1999/xhtml",
+        "next": Node {
+          "attribs": Object {
+            "class": "value placeholder",
+          },
+          "children": Array [
+            Node {
+              "attribs": Object {},
+              "children": Array [
+                Node {
+                  "attribs": Object {},
+                  "children": Array [
+                    Node {
+                      "data": "
+        span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          line-height: var(--select-height);
+          min-width: 0;
+        }
+      ",
+                      "next": null,
+                      "parent": [Circular],
+                      "prev": null,
+                      "type": "text",
+                    },
+                  ],
+                  "name": "style",
+                  "namespace": "http://www.w3.org/1999/xhtml",
+                  "next": null,
+                  "parent": [Circular],
+                  "prev": null,
+                  "type": "style",
+                  "x-attribsNamespace": Object {},
+                  "x-attribsPrefix": Object {},
+                },
+              ],
+              "name": "span",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "tag",
+              "x-attribsNamespace": Object {},
+              "x-attribsPrefix": Object {},
+            },
+          ],
+          "name": "span",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": Node {
+            "attribs": Object {},
+            "children": Array [
+              Node {
+                "data": "
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
+
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
+
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
+
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
+
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
+
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
+
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: #999;
+            }
+
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
+                "next": null,
+                "parent": [Circular],
+                "prev": null,
+                "type": "text",
+              },
+            ],
+            "name": "style",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": null,
+            "parent": [Circular],
+            "prev": [Circular],
+            "type": "style",
+            "x-attribsNamespace": Object {},
+            "x-attribsPrefix": Object {},
+          },
+          "parent": [Circular],
+          "prev": [Circular],
+          "type": "tag",
+          "x-attribsNamespace": Object {
+            "class": undefined,
+          },
+          "x-attribsPrefix": Object {
+            "class": undefined,
+          },
+        },
+        "parent": [Circular],
+        "prev": Node {
+          "attribs": Object {
+            "aria-expanded": "false",
+            "aria-haspopup": "listbox",
+            "readonly": "",
+            "role": "combobox",
+            "type": "search",
+            "unselectable": "on",
+          },
+          "children": Array [],
+          "name": "input",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": [Circular],
+          "parent": [Circular],
+          "prev": null,
+          "type": "tag",
+          "x-attribsNamespace": Object {
+            "aria-expanded": undefined,
+            "aria-haspopup": undefined,
+            "readonly": undefined,
+            "role": undefined,
+            "type": undefined,
+            "unselectable": undefined,
+          },
+          "x-attribsPrefix": Object {
+            "aria-expanded": undefined,
+            "aria-haspopup": undefined,
+            "readonly": undefined,
+            "role": undefined,
+            "type": undefined,
+            "unselectable": undefined,
+          },
+        },
+        "type": "style",
+        "x-attribsNamespace": Object {},
+        "x-attribsPrefix": Object {},
+      },
       Node {
         "attribs": Object {
           "class": "value placeholder",
@@ -357,86 +852,88 @@ initialize {
           "children": Array [
             Node {
               "data": "
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value &gt; :global(div),
-          .value &gt; :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #999;
-          }
+            .placeholder {
+              color: #999;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        ",
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
               "next": null,
               "parent": [Circular],
               "prev": null,
@@ -453,7 +950,71 @@ initialize {
           "x-attribsPrefix": Object {},
         },
         "parent": [Circular],
-        "prev": null,
+        "prev": Node {
+          "attribs": Object {},
+          "children": Array [
+            Node {
+              "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "text",
+            },
+          ],
+          "name": "style",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": [Circular],
+          "parent": [Circular],
+          "prev": Node {
+            "attribs": Object {
+              "aria-expanded": "false",
+              "aria-haspopup": "listbox",
+              "readonly": "",
+              "role": "combobox",
+              "type": "search",
+              "unselectable": "on",
+            },
+            "children": Array [],
+            "name": "input",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": [Circular],
+            "parent": [Circular],
+            "prev": null,
+            "type": "tag",
+            "x-attribsNamespace": Object {
+              "aria-expanded": undefined,
+              "aria-haspopup": undefined,
+              "readonly": undefined,
+              "role": undefined,
+              "type": undefined,
+              "unselectable": undefined,
+            },
+            "x-attribsPrefix": Object {
+              "aria-expanded": undefined,
+              "aria-haspopup": undefined,
+              "readonly": undefined,
+              "role": undefined,
+              "type": undefined,
+              "unselectable": undefined,
+            },
+          },
+          "type": "style",
+          "x-attribsNamespace": Object {},
+          "x-attribsPrefix": Object {},
+        },
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
@@ -467,86 +1028,88 @@ initialize {
         "children": Array [
           Node {
             "data": "
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value &gt; :global(div),
-          .value &gt; :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #999;
-          }
+            .placeholder {
+              color: #999;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        ",
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
             "next": null,
             "parent": [Circular],
             "prev": null,
@@ -608,7 +1171,71 @@ initialize {
           "namespace": "http://www.w3.org/1999/xhtml",
           "next": [Circular],
           "parent": [Circular],
-          "prev": null,
+          "prev": Node {
+            "attribs": Object {},
+            "children": Array [
+              Node {
+                "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+                "next": null,
+                "parent": [Circular],
+                "prev": null,
+                "type": "text",
+              },
+            ],
+            "name": "style",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": [Circular],
+            "parent": [Circular],
+            "prev": Node {
+              "attribs": Object {
+                "aria-expanded": "false",
+                "aria-haspopup": "listbox",
+                "readonly": "",
+                "role": "combobox",
+                "type": "search",
+                "unselectable": "on",
+              },
+              "children": Array [],
+              "name": "input",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "next": [Circular],
+              "parent": [Circular],
+              "prev": null,
+              "type": "tag",
+              "x-attribsNamespace": Object {
+                "aria-expanded": undefined,
+                "aria-haspopup": undefined,
+                "readonly": undefined,
+                "role": undefined,
+                "type": undefined,
+                "unselectable": undefined,
+              },
+              "x-attribsPrefix": Object {
+                "aria-expanded": undefined,
+                "aria-haspopup": undefined,
+                "readonly": undefined,
+                "role": undefined,
+                "type": undefined,
+                "unselectable": undefined,
+              },
+            },
+            "type": "style",
+            "x-attribsNamespace": Object {},
+            "x-attribsPrefix": Object {},
+          },
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
@@ -657,9 +1284,535 @@ exports[`Select should work with different icons 2`] = `
 initialize {
   "0": Node {
     "attribs": Object {
-      "class": "select  ",
+      "class": "select   ",
     },
     "children": Array [
+      Node {
+        "attribs": Object {
+          "aria-expanded": "false",
+          "aria-haspopup": "listbox",
+          "readonly": "",
+          "role": "combobox",
+          "type": "search",
+          "unselectable": "on",
+        },
+        "children": Array [],
+        "name": "input",
+        "namespace": "http://www.w3.org/1999/xhtml",
+        "next": Node {
+          "attribs": Object {},
+          "children": Array [
+            Node {
+              "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "text",
+            },
+          ],
+          "name": "style",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": Node {
+            "attribs": Object {
+              "class": "value placeholder",
+            },
+            "children": Array [
+              Node {
+                "attribs": Object {},
+                "children": Array [
+                  Node {
+                    "attribs": Object {},
+                    "children": Array [
+                      Node {
+                        "data": "
+        span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          line-height: var(--select-height);
+          min-width: 0;
+        }
+      ",
+                        "next": null,
+                        "parent": [Circular],
+                        "prev": null,
+                        "type": "text",
+                      },
+                    ],
+                    "name": "style",
+                    "namespace": "http://www.w3.org/1999/xhtml",
+                    "next": null,
+                    "parent": [Circular],
+                    "prev": null,
+                    "type": "style",
+                    "x-attribsNamespace": Object {},
+                    "x-attribsPrefix": Object {},
+                  },
+                ],
+                "name": "span",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "next": null,
+                "parent": [Circular],
+                "prev": null,
+                "type": "tag",
+                "x-attribsNamespace": Object {},
+                "x-attribsPrefix": Object {},
+              },
+            ],
+            "name": "span",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": Node {
+              "attribs": Object {
+                "class": "icon",
+              },
+              "children": Array [
+                Node {
+                  "attribs": Object {},
+                  "children": Array [
+                    Node {
+                      "data": "icon",
+                      "next": null,
+                      "parent": [Circular],
+                      "prev": null,
+                      "type": "text",
+                    },
+                  ],
+                  "name": "span",
+                  "namespace": "http://www.w3.org/1999/xhtml",
+                  "next": null,
+                  "parent": [Circular],
+                  "prev": null,
+                  "type": "tag",
+                  "x-attribsNamespace": Object {},
+                  "x-attribsPrefix": Object {},
+                },
+              ],
+              "name": "div",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "next": Node {
+                "attribs": Object {},
+                "children": Array [
+                  Node {
+                    "data": "
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
+
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
+
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
+
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
+
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
+
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
+
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: #999;
+            }
+
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
+                    "next": null,
+                    "parent": [Circular],
+                    "prev": null,
+                    "type": "text",
+                  },
+                ],
+                "name": "style",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "next": null,
+                "parent": [Circular],
+                "prev": [Circular],
+                "type": "style",
+                "x-attribsNamespace": Object {},
+                "x-attribsPrefix": Object {},
+              },
+              "parent": [Circular],
+              "prev": [Circular],
+              "type": "tag",
+              "x-attribsNamespace": Object {
+                "class": undefined,
+              },
+              "x-attribsPrefix": Object {
+                "class": undefined,
+              },
+            },
+            "parent": [Circular],
+            "prev": [Circular],
+            "type": "tag",
+            "x-attribsNamespace": Object {
+              "class": undefined,
+            },
+            "x-attribsPrefix": Object {
+              "class": undefined,
+            },
+          },
+          "parent": [Circular],
+          "prev": [Circular],
+          "type": "style",
+          "x-attribsNamespace": Object {},
+          "x-attribsPrefix": Object {},
+        },
+        "parent": [Circular],
+        "prev": null,
+        "type": "tag",
+        "x-attribsNamespace": Object {
+          "aria-expanded": undefined,
+          "aria-haspopup": undefined,
+          "readonly": undefined,
+          "role": undefined,
+          "type": undefined,
+          "unselectable": undefined,
+        },
+        "x-attribsPrefix": Object {
+          "aria-expanded": undefined,
+          "aria-haspopup": undefined,
+          "readonly": undefined,
+          "role": undefined,
+          "type": undefined,
+          "unselectable": undefined,
+        },
+      },
+      Node {
+        "attribs": Object {},
+        "children": Array [
+          Node {
+            "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+            "next": null,
+            "parent": [Circular],
+            "prev": null,
+            "type": "text",
+          },
+        ],
+        "name": "style",
+        "namespace": "http://www.w3.org/1999/xhtml",
+        "next": Node {
+          "attribs": Object {
+            "class": "value placeholder",
+          },
+          "children": Array [
+            Node {
+              "attribs": Object {},
+              "children": Array [
+                Node {
+                  "attribs": Object {},
+                  "children": Array [
+                    Node {
+                      "data": "
+        span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          line-height: var(--select-height);
+          min-width: 0;
+        }
+      ",
+                      "next": null,
+                      "parent": [Circular],
+                      "prev": null,
+                      "type": "text",
+                    },
+                  ],
+                  "name": "style",
+                  "namespace": "http://www.w3.org/1999/xhtml",
+                  "next": null,
+                  "parent": [Circular],
+                  "prev": null,
+                  "type": "style",
+                  "x-attribsNamespace": Object {},
+                  "x-attribsPrefix": Object {},
+                },
+              ],
+              "name": "span",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "tag",
+              "x-attribsNamespace": Object {},
+              "x-attribsPrefix": Object {},
+            },
+          ],
+          "name": "span",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": Node {
+            "attribs": Object {
+              "class": "icon",
+            },
+            "children": Array [
+              Node {
+                "attribs": Object {},
+                "children": Array [
+                  Node {
+                    "data": "icon",
+                    "next": null,
+                    "parent": [Circular],
+                    "prev": null,
+                    "type": "text",
+                  },
+                ],
+                "name": "span",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "next": null,
+                "parent": [Circular],
+                "prev": null,
+                "type": "tag",
+                "x-attribsNamespace": Object {},
+                "x-attribsPrefix": Object {},
+              },
+            ],
+            "name": "div",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": Node {
+              "attribs": Object {},
+              "children": Array [
+                Node {
+                  "data": "
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
+
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
+
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
+
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
+
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
+
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
+
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: #999;
+            }
+
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
+                  "next": null,
+                  "parent": [Circular],
+                  "prev": null,
+                  "type": "text",
+                },
+              ],
+              "name": "style",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "next": null,
+              "parent": [Circular],
+              "prev": [Circular],
+              "type": "style",
+              "x-attribsNamespace": Object {},
+              "x-attribsPrefix": Object {},
+            },
+            "parent": [Circular],
+            "prev": [Circular],
+            "type": "tag",
+            "x-attribsNamespace": Object {
+              "class": undefined,
+            },
+            "x-attribsPrefix": Object {
+              "class": undefined,
+            },
+          },
+          "parent": [Circular],
+          "prev": [Circular],
+          "type": "tag",
+          "x-attribsNamespace": Object {
+            "class": undefined,
+          },
+          "x-attribsPrefix": Object {
+            "class": undefined,
+          },
+        },
+        "parent": [Circular],
+        "prev": Node {
+          "attribs": Object {
+            "aria-expanded": "false",
+            "aria-haspopup": "listbox",
+            "readonly": "",
+            "role": "combobox",
+            "type": "search",
+            "unselectable": "on",
+          },
+          "children": Array [],
+          "name": "input",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": [Circular],
+          "parent": [Circular],
+          "prev": null,
+          "type": "tag",
+          "x-attribsNamespace": Object {
+            "aria-expanded": undefined,
+            "aria-haspopup": undefined,
+            "readonly": undefined,
+            "role": undefined,
+            "type": undefined,
+            "unselectable": undefined,
+          },
+          "x-attribsPrefix": Object {
+            "aria-expanded": undefined,
+            "aria-haspopup": undefined,
+            "readonly": undefined,
+            "role": undefined,
+            "type": undefined,
+            "unselectable": undefined,
+          },
+        },
+        "type": "style",
+        "x-attribsNamespace": Object {},
+        "x-attribsPrefix": Object {},
+      },
       Node {
         "attribs": Object {
           "class": "value placeholder",
@@ -742,86 +1895,88 @@ initialize {
             "children": Array [
               Node {
                 "data": "
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value &gt; :global(div),
-          .value &gt; :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #999;
-          }
+            .placeholder {
+              color: #999;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        ",
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
                 "next": null,
                 "parent": [Circular],
                 "prev": null,
@@ -848,7 +2003,71 @@ initialize {
           },
         },
         "parent": [Circular],
-        "prev": null,
+        "prev": Node {
+          "attribs": Object {},
+          "children": Array [
+            Node {
+              "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+              "next": null,
+              "parent": [Circular],
+              "prev": null,
+              "type": "text",
+            },
+          ],
+          "name": "style",
+          "namespace": "http://www.w3.org/1999/xhtml",
+          "next": [Circular],
+          "parent": [Circular],
+          "prev": Node {
+            "attribs": Object {
+              "aria-expanded": "false",
+              "aria-haspopup": "listbox",
+              "readonly": "",
+              "role": "combobox",
+              "type": "search",
+              "unselectable": "on",
+            },
+            "children": Array [],
+            "name": "input",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": [Circular],
+            "parent": [Circular],
+            "prev": null,
+            "type": "tag",
+            "x-attribsNamespace": Object {
+              "aria-expanded": undefined,
+              "aria-haspopup": undefined,
+              "readonly": undefined,
+              "role": undefined,
+              "type": undefined,
+              "unselectable": undefined,
+            },
+            "x-attribsPrefix": Object {
+              "aria-expanded": undefined,
+              "aria-haspopup": undefined,
+              "readonly": undefined,
+              "role": undefined,
+              "type": undefined,
+              "unselectable": undefined,
+            },
+          },
+          "type": "style",
+          "x-attribsNamespace": Object {},
+          "x-attribsPrefix": Object {},
+        },
         "type": "tag",
         "x-attribsNamespace": Object {
           "class": undefined,
@@ -890,86 +2109,88 @@ initialize {
           "children": Array [
             Node {
               "data": "
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value &gt; :global(div),
-          .value &gt; :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #999;
-          }
+            .placeholder {
+              color: #999;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        ",
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
               "next": null,
               "parent": [Circular],
               "prev": null,
@@ -1037,7 +2258,71 @@ initialize {
           "namespace": "http://www.w3.org/1999/xhtml",
           "next": [Circular],
           "parent": [Circular],
-          "prev": null,
+          "prev": Node {
+            "attribs": Object {},
+            "children": Array [
+              Node {
+                "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+                "next": null,
+                "parent": [Circular],
+                "prev": null,
+                "type": "text",
+              },
+            ],
+            "name": "style",
+            "namespace": "http://www.w3.org/1999/xhtml",
+            "next": [Circular],
+            "parent": [Circular],
+            "prev": Node {
+              "attribs": Object {
+                "aria-expanded": "false",
+                "aria-haspopup": "listbox",
+                "readonly": "",
+                "role": "combobox",
+                "type": "search",
+                "unselectable": "on",
+              },
+              "children": Array [],
+              "name": "input",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "next": [Circular],
+              "parent": [Circular],
+              "prev": null,
+              "type": "tag",
+              "x-attribsNamespace": Object {
+                "aria-expanded": undefined,
+                "aria-haspopup": undefined,
+                "readonly": undefined,
+                "role": undefined,
+                "type": undefined,
+                "unselectable": undefined,
+              },
+              "x-attribsPrefix": Object {
+                "aria-expanded": undefined,
+                "aria-haspopup": undefined,
+                "readonly": undefined,
+                "role": undefined,
+                "type": undefined,
+                "unselectable": undefined,
+              },
+            },
+            "type": "style",
+            "x-attribsNamespace": Object {},
+            "x-attribsPrefix": Object {},
+          },
           "type": "tag",
           "x-attribsNamespace": Object {
             "class": undefined,
@@ -1059,86 +2344,88 @@ initialize {
         "children": Array [
           Node {
             "data": "
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value &gt; :global(div),
-          .value &gt; :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value &gt; :global(div),
+            .value &gt; :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #999;
-          }
+            .placeholder {
+              color: #999;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        ",
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          ",
             "next": null,
             "parent": [Circular],
             "prev": null,
@@ -1230,7 +2517,71 @@ initialize {
             "namespace": "http://www.w3.org/1999/xhtml",
             "next": [Circular],
             "parent": [Circular],
-            "prev": null,
+            "prev": Node {
+              "attribs": Object {},
+              "children": Array [
+                Node {
+                  "data": "
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        ",
+                  "next": null,
+                  "parent": [Circular],
+                  "prev": null,
+                  "type": "text",
+                },
+              ],
+              "name": "style",
+              "namespace": "http://www.w3.org/1999/xhtml",
+              "next": [Circular],
+              "parent": [Circular],
+              "prev": Node {
+                "attribs": Object {
+                  "aria-expanded": "false",
+                  "aria-haspopup": "listbox",
+                  "readonly": "",
+                  "role": "combobox",
+                  "type": "search",
+                  "unselectable": "on",
+                },
+                "children": Array [],
+                "name": "input",
+                "namespace": "http://www.w3.org/1999/xhtml",
+                "next": [Circular],
+                "parent": [Circular],
+                "prev": null,
+                "type": "tag",
+                "x-attribsNamespace": Object {
+                  "aria-expanded": undefined,
+                  "aria-haspopup": undefined,
+                  "readonly": undefined,
+                  "role": undefined,
+                  "type": undefined,
+                  "unselectable": undefined,
+                },
+                "x-attribsPrefix": Object {
+                  "aria-expanded": undefined,
+                  "aria-haspopup": undefined,
+                  "readonly": undefined,
+                  "role": undefined,
+                  "type": undefined,
+                  "unselectable": undefined,
+                },
+              },
+              "type": "style",
+              "x-attribsNamespace": Object {},
+              "x-attribsPrefix": Object {},
+            },
             "type": "tag",
             "x-attribsNamespace": Object {
               "class": undefined,
@@ -1284,7 +2635,20 @@ initialize {
 `;
 
 exports[`Select should work with different status 1`] = `
-"<div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+"<div><div class=\\"select   \\"><input type=\\"search\\" role=\\"combobox\\" aria-haspopup=\\"listbox\\" readonly=\\"\\" unselectable=\\"on\\" aria-expanded=\\"false\\"><style>
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        </style><span class=\\"value placeholder\\"><span><style>
         span {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -1301,86 +2665,101 @@ exports[`Select should work with different status 1`] = `
           height: 1.214em;
         }
       </style></svg></div><style>
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
+
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: #999;
+            }
+
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          </style></div><div class=\\"select   \\"><input type=\\"search\\" role=\\"combobox\\" aria-haspopup=\\"listbox\\" readonly=\\"\\" unselectable=\\"on\\" aria-expanded=\\"false\\"><style>
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
             padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
+            font-size: 0;
+            border: none;
           }
-
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
-
-          .placeholder {
-            color: #999;
-          }
-
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        </style></div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+        </style><span class=\\"value placeholder\\"><span><style>
         span {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -1397,86 +2776,101 @@ exports[`Select should work with different status 1`] = `
           height: 1.214em;
         }
       </style></svg></div><style>
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #0070f3;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #3291ff;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #0761d1;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #0761d1;
+            }
 
-          .select:hover .icon {
-            color: #0761d1;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #0761d1;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
+
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: #999;
+            }
+
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #0070f3;
+            }
+          </style></div><div class=\\"select   \\"><input type=\\"search\\" role=\\"combobox\\" aria-haspopup=\\"listbox\\" readonly=\\"\\" unselectable=\\"on\\" aria-expanded=\\"false\\"><style>
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
             padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
+            font-size: 0;
+            border: none;
           }
-
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
-
-          .placeholder {
-            color: #999;
-          }
-
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #0070f3;
-          }
-        </style></div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+        </style><span class=\\"value placeholder\\"><span><style>
         span {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -1493,86 +2887,101 @@ exports[`Select should work with different status 1`] = `
           height: 1.214em;
         }
       </style></svg></div><style>
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #f5a623;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #f7b955;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #ab570a;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #ab570a;
+            }
 
-          .select:hover .icon {
-            color: #ab570a;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #ab570a;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
+
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: #999;
+            }
+
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #f5a623;
+            }
+          </style></div><div class=\\"select   \\"><input type=\\"search\\" role=\\"combobox\\" aria-haspopup=\\"listbox\\" readonly=\\"\\" unselectable=\\"on\\" aria-expanded=\\"false\\"><style>
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
             padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
+            font-size: 0;
+            border: none;
           }
-
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
-
-          .placeholder {
-            color: #999;
-          }
-
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #f5a623;
-          }
-        </style></div><div class=\\"select  \\"><span class=\\"value placeholder\\"><span><style>
+        </style><span class=\\"value placeholder\\"><span><style>
         span {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -1589,84 +2998,86 @@ exports[`Select should work with different status 1`] = `
           height: 1.214em;
         }
       </style></svg></div><style>
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #e00;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #ff1a1a;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #c50000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #c50000;
+            }
 
-          .select:hover .icon {
-            color: #c50000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #c50000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #e00;
-          }
+            .placeholder {
+              color: #e00;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #e00;
-          }
-        </style></div></div>"
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #e00;
+            }
+          </style></div></div>"
 `;

--- a/components/select/__tests__/__snapshots__/multiple.test.tsx.snap
+++ b/components/select/__tests__/__snapshots__/multiple.test.tsx.snap
@@ -1,7 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select Multiple should render correctly 1`] = `
-"<div class=\\"select multiple \\"><span class=\\"value placeholder\\"><span><style>
+"<div class=\\"select  multiple \\"><input type=\\"search\\" role=\\"combobox\\" aria-haspopup=\\"listbox\\" readonly=\\"\\" unselectable=\\"on\\" aria-expanded=\\"false\\"><style>
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        </style><span class=\\"value placeholder\\"><span><style>
         span {
           overflow: hidden;
           text-overflow: ellipsis;
@@ -91,84 +104,86 @@ exports[`Select Multiple should render correctly 1`] = `
           height: 1.214em;
         }
       </style></svg></div><style>
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: pointer;
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid #eaeaea;
-            border-radius: 5px;
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: pointer;
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid #eaeaea;
+              border-radius: 5px;
 
-            background-color: #fff;
-            --select-font-size: calc(0.875 * 16px);
-            --select-height: calc(2.25 * 16px);
-            min-width: 11.5em;
-            width: initial;
-            height: var(--select-height);
-            padding: 0 calc(0.334 * 16px) 0
-              calc(0.667 * 16px);
-            margin: 0 0 0 0;
-          }
+              background-color: #fff;
+              --select-font-size: calc(0.875 * 16px);
+              --select-height: calc(2.25 * 16px);
+              min-width: 11.5em;
+              width: initial;
+              height: var(--select-height);
+              padding: 0 calc(0.334 * 16px) 0
+                calc(0.667 * 16px);
+              margin: 0 0 0 0;
+            }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
-              calc(0.667 * 16px);
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: calc(0.334 * 16px) calc(0.334 * 16px) calc(0.334 * 16px)
+                calc(0.667 * 16px);
+            }
 
-          .select:hover {
-            border-color: #000;
-          }
+            .select.active,
+            .select:hover {
+              border-color: #000;
+            }
 
-          .select:hover .icon {
-            color: #000;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: #000;
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: #000;
-            width: calc(100% - 1.25em);
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: #000;
+              width: calc(100% - 1.25em);
+            }
 
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
 
-          .placeholder {
-            color: #999;
-          }
+            .placeholder {
+              color: #999;
+            }
 
-          .icon {
-            position: absolute;
-            right: 4pt;
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(0deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: #666;
-          }
-        </style></div>"
+            .icon {
+              position: absolute;
+              right: 4pt;
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(0deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: #666;
+            }
+          </style></div>"
 `;

--- a/components/select/__tests__/events.test.tsx
+++ b/components/select/__tests__/events.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { Select } from 'components'
+import { nativeEvent, updateWrapper } from 'tests/utils'
+
+describe('Select Events', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.append(container)
+  })
+
+  it('ref should be able to control the focus correctly', () => {
+    const ref = React.createRef<HTMLDivElement>()
+    const wrapper = mount(<Select ref={ref} />, { attachTo: container })
+    const input = wrapper.find('input').at(0).getDOMNode()
+    expect(document.activeElement?.outerHTML).not.toEqual(input.outerHTML)
+    ref.current?.focus()
+    expect(document.activeElement?.outerHTML).toEqual(input.outerHTML)
+    ref.current?.blur()
+    expect(document.activeElement?.outerHTML).not.toEqual(input.outerHTML)
+  })
+
+  it('should prevent mouse event when click background', async () => {
+    let visible = false
+    const handler = jest.fn().mockImplementation(next => {
+      visible = next
+    })
+    const wrapper = mount(<Select onDropdownVisibleChange={handler} />, {
+      attachTo: container,
+    })
+    expect(visible).toBe(false)
+    expect(handler).not.toBeCalled()
+    wrapper.find('.select').simulate('click', nativeEvent)
+    await updateWrapper(wrapper, 300)
+    expect(visible).toBe(true)
+    expect(handler).toBeCalledTimes(1)
+
+    wrapper.find('.dropdown').simulate('click', nativeEvent)
+    await updateWrapper(wrapper, 300)
+    expect(visible).toBe(true)
+    expect(handler).toBeCalledTimes(1)
+  })
+
+  it('scrollTo should be work correctly', async () => {
+    const ref = React.createRef<HTMLDivElement>()
+    const handler = jest.fn()
+    window.HTMLElement.prototype.scrollTo = jest.fn().mockImplementation(handler)
+    const wrapper = mount(
+      <Select ref={ref}>
+        <Select.Option value="hello">world</Select.Option>
+      </Select>,
+      { attachTo: container },
+    )
+    wrapper.find('.select').simulate('click', nativeEvent)
+    await updateWrapper(wrapper, 300)
+    ref.current?.scrollTo({ top: 200 })
+    expect(handler).toBeCalled()
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
+
+  afterEach(() => {
+    document.body.removeChild(container!)
+  })
+})

--- a/components/select/__tests__/index.test.tsx
+++ b/components/select/__tests__/index.test.tsx
@@ -32,6 +32,9 @@ describe('Select', () => {
       <Select>
         <Select.Option label>1</Select.Option>
         <Select.Option divider>1</Select.Option>
+        <Select.Option divider label>
+          1
+        </Select.Option>
         <Select.Option value="1">1</Select.Option>
         <Select.Option value="2">Option 2</Select.Option>
       </Select>,
@@ -96,6 +99,25 @@ describe('Select', () => {
       <Select onChange={changeHandler}>
         <Select.Option value="1">1</Select.Option>
         <Select.Option value="2" disabled>
+          Option 2
+        </Select.Option>
+      </Select>,
+    )
+    wrapper.find('.select').simulate('click', nativeEvent)
+    wrapper.find('.select-dropdown').find('.option').at(1).simulate('click', nativeEvent)
+    await updateWrapper(wrapper, 350)
+    expect(changeHandler).not.toHaveBeenCalled()
+    expect(value).not.toEqual('2')
+    changeHandler.mockRestore()
+  })
+
+  it('should ignore option when prevent all', async () => {
+    let value = ''
+    const changeHandler = jest.fn().mockImplementation(val => (value = val))
+    const wrapper = mount(
+      <Select onChange={changeHandler}>
+        <Select.Option value="1">1</Select.Option>
+        <Select.Option value="2" preventAllEvents>
           Option 2
         </Select.Option>
       </Select>,

--- a/components/select/index.ts
+++ b/components/select/index.ts
@@ -6,6 +6,6 @@ export type SelectComponentType = typeof Select & {
 }
 ;(Select as SelectComponentType).Option = SelectOption
 
-export type { SelectProps, SelectTypes } from './select'
+export type { SelectProps, SelectTypes, SelectRef } from './select'
 export type { SelectOptionProps } from './select-option'
 export default Select as SelectComponentType

--- a/components/select/select-dropdown.tsx
+++ b/components/select/select-dropdown.tsx
@@ -62,6 +62,7 @@ const SelectDropdown = React.forwardRef<
               overflow-y: auto;
               overflow-anchor: none;
               padding: 0.38em 0;
+              scroll-behavior: smooth;
             }
           `}</style>
         </div>

--- a/components/select/select-dropdown.tsx
+++ b/components/select/select-dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react'
+import React, { CSSProperties, useImperativeHandle, useRef } from 'react'
 import useTheme from '../use-theme'
 import { useSelectContext } from './select-context'
 import Dropdown from '../shared/dropdown'
@@ -19,40 +19,56 @@ const defaultProps = {
 type NativeAttrs = Omit<React.HTMLAttributes<any>, keyof Props>
 export type SelectDropdownProps = Props & NativeAttrs
 
-const SelectDropdown: React.FC<React.PropsWithChildren<SelectDropdownProps>> = ({
-  visible,
-  children,
-  className,
-  dropdownStyle,
-  disableMatchWidth,
-  getPopupContainer,
-}: React.PropsWithChildren<SelectDropdownProps> & typeof defaultProps) => {
-  const theme = useTheme()
-  const { ref } = useSelectContext()
+const SelectDropdown = React.forwardRef<
+  HTMLDivElement | null,
+  React.PropsWithChildren<SelectDropdownProps>
+>(
+  (
+    {
+      visible,
+      children,
+      className,
+      dropdownStyle,
+      disableMatchWidth,
+      getPopupContainer,
+    }: React.PropsWithChildren<SelectDropdownProps> & typeof defaultProps,
+    dropdownRef,
+  ) => {
+    const theme = useTheme()
+    const internalDropdownRef = useRef<HTMLDivElement | null>(null)
+    const { ref } = useSelectContext()
+    useImperativeHandle<HTMLDivElement | null, HTMLDivElement | null>(
+      dropdownRef,
+      () => internalDropdownRef.current,
+    )
 
-  return (
-    <Dropdown
-      parent={ref}
-      visible={visible}
-      disableMatchWidth={disableMatchWidth}
-      getPopupContainer={getPopupContainer}>
-      <div className={`select-dropdown ${className}`} style={dropdownStyle}>
-        {children}
-        <style jsx>{`
-          .select-dropdown {
-            border-radius: ${theme.layout.radius};
-            box-shadow: ${theme.expressiveness.shadowLarge};
-            background-color: ${theme.palette.background};
-            max-height: 17em;
-            overflow-y: auto;
-            overflow-anchor: none;
-            padding: 0.38em 0;
-          }
-        `}</style>
-      </div>
-    </Dropdown>
-  )
-}
+    return (
+      <Dropdown
+        parent={ref}
+        visible={visible}
+        disableMatchWidth={disableMatchWidth}
+        getPopupContainer={getPopupContainer}>
+        <div
+          ref={internalDropdownRef}
+          className={`select-dropdown ${className}`}
+          style={dropdownStyle}>
+          {children}
+          <style jsx>{`
+            .select-dropdown {
+              border-radius: ${theme.layout.radius};
+              box-shadow: ${theme.expressiveness.shadowLarge};
+              background-color: ${theme.palette.background};
+              max-height: 17em;
+              overflow-y: auto;
+              overflow-anchor: none;
+              padding: 0.38em 0;
+            }
+          `}</style>
+        </div>
+      </Dropdown>
+    )
+  },
+)
 
 SelectDropdown.defaultProps = defaultProps
 SelectDropdown.displayName = 'GeistSelectDropdown'

--- a/components/select/select-input.tsx
+++ b/components/select/select-input.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useImperativeHandle, useRef } from 'react'
+
+export type SelectInputProps = {
+  visible: boolean
+  onBlur: () => void
+  onFocus: () => void
+}
+
+const SelectInput = React.forwardRef<HTMLInputElement | null, SelectInputProps>(
+  ({ visible, onBlur, onFocus }, inputRef) => {
+    const ref = useRef<HTMLInputElement | null>(null)
+    useImperativeHandle<HTMLInputElement | null, HTMLInputElement | null>(
+      inputRef,
+      () => ref.current,
+    )
+
+    useEffect(() => {
+      if (visible) {
+        ref.current?.focus()
+      }
+    }, [visible])
+
+    return (
+      <>
+        <input
+          ref={ref}
+          type="search"
+          role="combobox"
+          aria-haspopup="listbox"
+          readOnly
+          unselectable="on"
+          aria-expanded={visible}
+          onBlur={onBlur}
+          onFocus={onFocus}
+        />
+        <style jsx>{`
+          input {
+            position: fixed;
+            top: -10000px;
+            left: -10000px;
+            opacity: 0;
+            z-index: -1;
+            width: 0;
+            height: 0;
+            padding: 0;
+            font-size: 0;
+            border: none;
+          }
+        `}</style>
+      </>
+    )
+  },
+)
+
+SelectInput.displayName = 'GiestSelectInput'
+export default SelectInput

--- a/components/select/select-option.tsx
+++ b/components/select/select-option.tsx
@@ -75,6 +75,10 @@ const SelectOptionComponent: React.FC<React.PropsWithChildren<SelectOptionProps>
     if (isDisabled || isLabel) return
     updateValue && updateValue(identValue)
   }
+  const touchStartHandler = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (preventAllEvents) return
+    event.preventDefault()
+  }
 
   return (
     <>
@@ -82,6 +86,7 @@ const SelectOptionComponent: React.FC<React.PropsWithChildren<SelectOptionProps>
         className={`option ${divider ? 'divider' : ''} ${
           label ? 'label' : ''
         } ${className}`}
+        onMouseDown={touchStartHandler}
         onClick={clickHandler}
         {...props}>
         <Ellipsis height={`calc(1.688 * ${theme.layout.gap})`}>{children}</Ellipsis>

--- a/components/select/select-option.tsx
+++ b/components/select/select-option.tsx
@@ -75,23 +75,15 @@ const SelectOptionComponent: React.FC<React.PropsWithChildren<SelectOptionProps>
     if (isDisabled || isLabel) return
     updateValue && updateValue(identValue)
   }
-  const touchStartHandler = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (preventAllEvents) return
-    event.preventDefault()
-  }
 
   return (
-    <>
-      <div
-        className={`option ${divider ? 'divider' : ''} ${
-          label ? 'label' : ''
-        } ${className}`}
-        onMouseDown={touchStartHandler}
-        onClick={clickHandler}
-        {...props}>
-        <Ellipsis height={`calc(1.688 * ${theme.layout.gap})`}>{children}</Ellipsis>
-      </div>
-
+    <div
+      className={`option ${divider ? 'divider' : ''} ${
+        label ? 'label' : ''
+      } ${className}`}
+      onClick={clickHandler}
+      {...props}>
+      <Ellipsis height={SCALES.height(2.25)}>{children}</Ellipsis>
       <style jsx>{`
         .option {
           display: flex;
@@ -138,7 +130,7 @@ const SelectOptionComponent: React.FC<React.PropsWithChildren<SelectOptionProps>
           font-weight: 500;
         }
       `}</style>
-    </>
+    </div>
   )
 }
 

--- a/components/select/select.tsx
+++ b/components/select/select.tsx
@@ -146,6 +146,7 @@ const SelectComponent = React.forwardRef<SelectRef, React.PropsWithChildren<Sele
       event.preventDefault()
     }
     const mouseDownHandler = (event: React.MouseEvent<HTMLDivElement>) => {
+      /* istanbul ignore next */
       if (visible) {
         event.preventDefault()
       }

--- a/components/select/select.tsx
+++ b/components/select/select.tsx
@@ -1,7 +1,13 @@
-import React, { CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
+import React, {
+  CSSProperties,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { NormalTypes } from '../utils/prop-types'
 import useTheme from '../use-theme'
-import useClickAway from '../utils/use-click-away'
 import useCurrentState from '../utils/use-current-state'
 import { pickChildByProps } from '../utils/collections'
 import SelectIcon from './select-icon'
@@ -11,8 +17,14 @@ import Grid from '../grid'
 import { SelectContext, SelectConfig } from './select-context'
 import { getColors } from './styles'
 import Ellipsis from '../shared/ellipsis'
+import SelectInput from './select-input'
 import useScaleable, { withScaleable } from '../use-scaleable'
 
+export type SelectRef = {
+  focus: () => void
+  blur: () => void
+  scrollTo?: (options?: ScrollToOptions) => void
+}
 export type SelectTypes = NormalTypes
 interface Props {
   disabled?: boolean
@@ -29,6 +41,7 @@ interface Props {
   dropdownClassName?: string
   dropdownStyle?: CSSProperties
   disableMatchWidth?: boolean
+  onDropdownVisibleChange?: (visible: boolean) => void
   getPopupContainer?: () => HTMLElement | null
 }
 
@@ -41,220 +54,267 @@ const defaultProps = {
   clearable: true,
   className: '',
   disableMatchWidth: false,
+  onDropdownVisibleChange: () => {},
 }
 
 type NativeAttrs = Omit<React.HTMLAttributes<any>, keyof Props>
 export type SelectProps = Props & NativeAttrs
 
-const SelectComponent: React.FC<React.PropsWithChildren<SelectProps>> = ({
-  children,
-  type,
-  disabled,
-  initialValue: init,
-  value: customValue,
-  icon: Icon,
-  onChange,
-  pure,
-  multiple,
-  clearable,
-  placeholder,
-  className,
-  dropdownClassName,
-  dropdownStyle,
-  disableMatchWidth,
-  getPopupContainer,
-  ...props
-}: React.PropsWithChildren<SelectProps> & typeof defaultProps) => {
-  const theme = useTheme()
-  const { SCALES } = useScaleable()
-  const ref = useRef<HTMLDivElement>(null)
-  const [visible, setVisible] = useState<boolean>(false)
-  const [value, setValue, valueRef] = useCurrentState<string | string[] | undefined>(
-    () => {
-      if (!multiple) return init
-      if (Array.isArray(init)) return init
-      return typeof init === 'undefined' ? [] : [init]
-    },
-  )
-  const isEmpty = useMemo(() => {
-    if (!Array.isArray(value)) return !value
-    return value.length === 0
-  }, [value])
+const SelectComponent = React.forwardRef<SelectRef, React.PropsWithChildren<SelectProps>>(
+  (
+    {
+      children,
+      type,
+      disabled,
+      initialValue: init,
+      value: customValue,
+      icon: Icon,
+      onChange,
+      pure,
+      multiple,
+      clearable,
+      placeholder,
+      className,
+      dropdownClassName,
+      dropdownStyle,
+      disableMatchWidth,
+      getPopupContainer,
+      onDropdownVisibleChange,
+      ...props
+    }: React.PropsWithChildren<SelectProps> & typeof defaultProps,
+    selectRef,
+  ) => {
+    const theme = useTheme()
+    const { SCALES } = useScaleable()
+    const ref = useRef<HTMLDivElement>(null)
+    const inputRef = useRef<HTMLInputElement>(null)
+    const dropdownRef = useRef<HTMLDivElement>(null)
+    const [visible, setVisible] = useState<boolean>(false)
+    const [selectFocus, setSelectFocus] = useState<boolean>(false)
+    const [value, setValue, valueRef] = useCurrentState<string | string[] | undefined>(
+      () => {
+        if (!multiple) return init
+        if (Array.isArray(init)) return init
+        return typeof init === 'undefined' ? [] : [init]
+      },
+    )
+    const isEmpty = useMemo(() => {
+      if (!Array.isArray(value)) return !value
+      return value.length === 0
+    }, [value])
 
-  const { border, borderHover, iconBorder, placeholderColor } = useMemo(
-    () => getColors(theme.palette, type),
-    [theme.palette, type],
-  )
+    const { border, borderActive, iconBorder, placeholderColor } = useMemo(
+      () => getColors(theme.palette, type),
+      [theme.palette, type],
+    )
 
-  const updateVisible = (next: boolean) => setVisible(next)
-  const updateValue = (next: string) => {
-    setValue(last => {
-      if (!Array.isArray(last)) return next
-      if (!last.includes(next)) return [...last, next]
-      return last.filter(item => item !== next)
-    })
-    onChange && onChange(valueRef.current as string | string[])
-    if (!multiple) {
-      setVisible(false)
+    const updateVisible = (next: boolean) => {
+      onDropdownVisibleChange(next)
+      setVisible(next)
     }
-  }
+    const updateValue = (next: string) => {
+      setValue(last => {
+        if (!Array.isArray(last)) return next
+        if (!last.includes(next)) return [...last, next]
+        return last.filter(item => item !== next)
+      })
+      onChange && onChange(valueRef.current as string | string[])
+      if (!multiple) {
+        updateVisible(false)
+      }
+    }
 
-  const initialValue: SelectConfig = useMemo(
-    () => ({
-      value,
-      visible,
-      updateValue,
-      updateVisible,
-      ref,
-      disableAll: disabled,
-    }),
-    [visible, disabled, ref, value, multiple],
-  )
+    const initialValue: SelectConfig = useMemo(
+      () => ({
+        value,
+        visible,
+        updateValue,
+        updateVisible,
+        ref,
+        disableAll: disabled,
+      }),
+      [visible, disabled, ref, value, multiple],
+    )
 
-  const clickHandler = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation()
-    event.nativeEvent.stopImmediatePropagation()
-    event.preventDefault()
-    if (disabled) return
-    setVisible(!visible)
-  }
+    const clickHandler = (event: React.MouseEvent<HTMLDivElement>) => {
+      event.stopPropagation()
+      event.nativeEvent.stopImmediatePropagation()
+      event.preventDefault()
+      if (disabled) return
 
-  useClickAway(ref, () => setVisible(false))
-  useEffect(() => {
-    if (customValue === undefined) return
-    setValue(customValue)
-  }, [customValue])
+      updateVisible(!visible)
+      event.preventDefault()
+    }
+    const mouseDownHandler = (event: React.MouseEvent<HTMLDivElement>) => {
+      if (visible) {
+        event.preventDefault()
+      }
+    }
 
-  const selectedChild = useMemo(() => {
-    const [, optionChildren] = pickChildByProps(children, 'value', value)
-    return React.Children.map(optionChildren, child => {
-      if (!React.isValidElement(child)) return null
-      const el = React.cloneElement(child, { preventAllEvents: true })
-      if (!multiple) return el
-      return (
-        <SelectMultipleValue
-          disabled={disabled}
-          onClear={clearable ? () => updateValue(child.props.value) : null}>
-          {el}
-        </SelectMultipleValue>
-      )
-    })
-  }, [value, children, multiple])
+    useEffect(() => {
+      if (customValue === undefined) return
+      setValue(customValue)
+    }, [customValue])
+    useImperativeHandle(
+      selectRef,
+      () => ({
+        focus: () => inputRef.current?.focus(),
+        blur: () => inputRef.current?.blur(),
+        scrollTo: options => dropdownRef.current?.scrollTo(options),
+      }),
+      [inputRef, dropdownRef],
+    )
 
-  return (
-    <SelectContext.Provider value={initialValue}>
-      <div
-        className={`select ${multiple ? 'multiple' : ''} ${className}`}
-        ref={ref}
-        onClick={clickHandler}
-        {...props}>
-        {isEmpty && (
-          <span className="value placeholder">
-            <Ellipsis height="var(--select-height)">{placeholder}</Ellipsis>
-          </span>
-        )}
-        {value && !multiple && <span className="value">{selectedChild}</span>}
-        {value && multiple && <Grid.Container gap={0.5}>{selectedChild}</Grid.Container>}
-        <SelectDropdown
-          visible={visible}
-          className={dropdownClassName}
-          dropdownStyle={dropdownStyle}
-          disableMatchWidth={disableMatchWidth}
-          getPopupContainer={getPopupContainer}>
-          {children}
-        </SelectDropdown>
-        {!pure && (
-          <div className="icon">
-            <Icon />
-          </div>
-        )}
-        <style jsx>{`
-          .select {
-            display: inline-flex;
-            align-items: center;
-            user-select: none;
-            white-space: nowrap;
-            position: relative;
-            cursor: ${disabled ? 'not-allowed' : 'pointer'};
-            max-width: 90vw;
-            overflow: hidden;
-            transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
-              box-shadow 200ms ease 0s;
-            border: 1px solid ${border};
-            border-radius: ${theme.layout.radius};
+    const selectedChild = useMemo(() => {
+      const [, optionChildren] = pickChildByProps(children, 'value', value)
+      return React.Children.map(optionChildren, child => {
+        if (!React.isValidElement(child)) return null
+        const el = React.cloneElement(child, { preventAllEvents: true })
+        if (!multiple) return el
+        return (
+          <SelectMultipleValue
+            disabled={disabled}
+            onClear={clearable ? () => updateValue(child.props.value) : null}>
+            {el}
+          </SelectMultipleValue>
+        )
+      })
+    }, [value, children, multiple])
 
-            background-color: ${disabled
-              ? theme.palette.accents_1
-              : theme.palette.background};
-            --select-font-size: ${SCALES.font(0.875)};
-            --select-height: ${SCALES.height(2.25)};
-            min-width: 11.5em;
-            width: ${SCALES.width(1, 'initial')};
-            height: var(--select-height);
-            padding: ${SCALES.pt(0)} ${SCALES.pr(0.334)} ${SCALES.pb(0)}
-              ${SCALES.pl(0.667)};
-            margin: ${SCALES.mt(0)} ${SCALES.mr(0)} ${SCALES.mb(0)} ${SCALES.ml(0)};
-          }
+    const onInputBlur = () => {
+      updateVisible(false)
+      setSelectFocus(false)
+    }
 
-          .multiple {
-            height: auto;
-            min-height: var(--select-height);
-            padding: ${SCALES.pt(0.334)} ${SCALES.pr(0.334)} ${SCALES.pb(0.334)}
-              ${SCALES.pl(0.667)};
-          }
+    return (
+      <SelectContext.Provider value={initialValue}>
+        <div
+          className={`select ${selectFocus || visible ? 'active' : ''} ${
+            multiple ? 'multiple' : ''
+          } ${className}`}
+          ref={ref}
+          onClick={clickHandler}
+          onMouseDown={mouseDownHandler}
+          {...props}>
+          <SelectInput
+            ref={inputRef}
+            visible={visible}
+            onBlur={onInputBlur}
+            onFocus={() => setSelectFocus(true)}
+          />
+          {isEmpty && (
+            <span className="value placeholder">
+              <Ellipsis height="var(--select-height)">{placeholder}</Ellipsis>
+            </span>
+          )}
+          {value && !multiple && <span className="value">{selectedChild}</span>}
+          {value && multiple && (
+            <Grid.Container gap={0.5}>{selectedChild}</Grid.Container>
+          )}
+          <SelectDropdown
+            ref={dropdownRef}
+            visible={visible}
+            className={dropdownClassName}
+            dropdownStyle={dropdownStyle}
+            disableMatchWidth={disableMatchWidth}
+            getPopupContainer={getPopupContainer}>
+            {children}
+          </SelectDropdown>
+          {!pure && (
+            <div className="icon">
+              <Icon />
+            </div>
+          )}
+          <style jsx>{`
+            .select {
+              display: inline-flex;
+              align-items: center;
+              user-select: none;
+              white-space: nowrap;
+              position: relative;
+              cursor: ${disabled ? 'not-allowed' : 'pointer'};
+              max-width: 90vw;
+              overflow: hidden;
+              transition: border 150ms ease-in 0s, color 200ms ease-out 0s,
+                box-shadow 200ms ease 0s;
+              border: 1px solid ${border};
+              border-radius: ${theme.layout.radius};
 
-          .select:hover {
-            border-color: ${disabled ? theme.palette.border : borderHover};
-          }
+              background-color: ${disabled
+                ? theme.palette.accents_1
+                : theme.palette.background};
+              --select-font-size: ${SCALES.font(0.875)};
+              --select-height: ${SCALES.height(2.25)};
+              min-width: 11.5em;
+              width: ${SCALES.width(1, 'initial')};
+              height: var(--select-height);
+              padding: ${SCALES.pt(0)} ${SCALES.pr(0.334)} ${SCALES.pb(0)}
+                ${SCALES.pl(0.667)};
+              margin: ${SCALES.mt(0)} ${SCALES.mr(0)} ${SCALES.mb(0)} ${SCALES.ml(0)};
+            }
 
-          .select:hover .icon {
-            color: ${disabled ? theme.palette.accents_5 : borderHover};
-          }
+            .multiple {
+              height: auto;
+              min-height: var(--select-height);
+              padding: ${SCALES.pt(0.334)} ${SCALES.pr(0.334)} ${SCALES.pb(0.334)}
+                ${SCALES.pl(0.667)};
+            }
 
-          .value {
-            display: inline-flex;
-            flex: 1;
-            height: 100%;
-            align-items: center;
-            line-height: 1;
-            padding: 0;
-            margin-right: 1.25em;
-            font-size: var(--select-font-size);
-            color: ${disabled ? theme.palette.accents_4 : theme.palette.foreground};
-            width: calc(100% - 1.25em);
-          }
+            .select.active,
+            .select:hover {
+              border-color: ${disabled ? theme.palette.border : borderActive};
+            }
 
-          .value > :global(div),
-          .value > :global(div:hover) {
-            border-radius: 0;
-            background-color: transparent;
-            padding: 0;
-            margin: 0;
-            color: inherit;
-          }
+            .select.active.icon,
+            .select:hover .icon {
+              color: ${disabled ? theme.palette.accents_5 : borderActive};
+            }
 
-          .placeholder {
-            color: ${placeholderColor};
-          }
+            .value {
+              display: inline-flex;
+              flex: 1;
+              height: 100%;
+              align-items: center;
+              line-height: 1;
+              padding: 0;
+              margin-right: 1.25em;
+              font-size: var(--select-font-size);
+              color: ${disabled ? theme.palette.accents_4 : theme.palette.foreground};
+              width: calc(100% - 1.25em);
+            }
 
-          .icon {
-            position: absolute;
-            right: ${theme.layout.gapQuarter};
-            font-size: var(--select-font-size);
-            top: 50%;
-            bottom: 0;
-            transform: translateY(-50%) rotate(${visible ? '180' : '0'}deg);
-            pointer-events: none;
-            transition: transform 200ms ease;
-            display: flex;
-            align-items: center;
-            color: ${iconBorder};
-          }
-        `}</style>
-      </div>
-    </SelectContext.Provider>
-  )
-}
+            .value > :global(div),
+            .value > :global(div:hover) {
+              border-radius: 0;
+              background-color: transparent;
+              padding: 0;
+              margin: 0;
+              color: inherit;
+            }
+
+            .placeholder {
+              color: ${placeholderColor};
+            }
+
+            .icon {
+              position: absolute;
+              right: ${theme.layout.gapQuarter};
+              font-size: var(--select-font-size);
+              top: 50%;
+              bottom: 0;
+              transform: translateY(-50%) rotate(${visible ? '180' : '0'}deg);
+              pointer-events: none;
+              transition: transform 200ms ease;
+              display: flex;
+              align-items: center;
+              color: ${iconBorder};
+            }
+          `}</style>
+        </div>
+      </SelectContext.Provider>
+    )
+  },
+)
 
 SelectComponent.defaultProps = defaultProps
 SelectComponent.displayName = 'GeistSelect'

--- a/components/select/styles.ts
+++ b/components/select/styles.ts
@@ -3,7 +3,7 @@ import { GeistUIThemesPalette } from '../themes/presets'
 
 export type SelectColor = {
   border: string
-  borderHover: string
+  borderActive: string
   iconBorder: string
   placeholderColor: string
 }
@@ -15,34 +15,32 @@ export const getColors = (
   const colors: { [key in NormalTypes]: SelectColor } = {
     default: {
       border: palette.border,
-      borderHover: palette.foreground,
+      borderActive: palette.foreground,
       iconBorder: palette.accents_5,
       placeholderColor: palette.accents_3,
     },
     secondary: {
       border: palette.border,
-      borderHover: palette.foreground,
+      borderActive: palette.foreground,
       iconBorder: palette.accents_5,
       placeholderColor: palette.accents_3,
     },
     success: {
-      border: palette.success,
-      borderHover: palette.successDark,
+      border: palette.successLight,
+      borderActive: palette.successDark,
       iconBorder: palette.success,
       placeholderColor: palette.accents_3,
     },
     warning: {
-      border: palette.warning,
-      borderHover: palette.warningDark,
+      border: palette.warningLight,
+      borderActive: palette.warningDark,
       iconBorder: palette.warning,
-
       placeholderColor: palette.accents_3,
     },
     error: {
-      border: palette.error,
-      borderHover: palette.errorDark,
+      border: palette.errorLight,
+      borderActive: palette.errorDark,
       iconBorder: palette.error,
-
       placeholderColor: palette.error,
     },
   }

--- a/components/shared/dropdown.tsx
+++ b/components/shared/dropdown.tsx
@@ -102,6 +102,10 @@ const Dropdown: React.FC<React.PropsWithChildren<Props>> = React.memo(
 
     const clickHandler = (event: React.MouseEvent<HTMLDivElement>) => {
       event.stopPropagation()
+      event.nativeEvent.stopImmediatePropagation()
+      event.preventDefault()
+    }
+    const mouseDownHandler = (event: React.MouseEvent<HTMLDivElement>) => {
       event.preventDefault()
     }
 
@@ -110,7 +114,8 @@ const Dropdown: React.FC<React.PropsWithChildren<Props>> = React.memo(
       <CssTransition visible={visible}>
         <div
           className={`dropdown ${disableMatchWidth ? 'disable-match' : 'width-match'}`}
-          onClick={clickHandler}>
+          onClick={clickHandler}
+          onMouseDown={mouseDownHandler}>
           {children}
           <style jsx>{`
             .dropdown {

--- a/pages/en-us/components/select.mdx
+++ b/pages/en-us/components/select.mdx
@@ -251,6 +251,8 @@ Display a dropdown list of items.
 | ------------------- | ---------------------- | ---------------- | ------------------- | ------- |
 | **value**(required) | unique ident value     | `string`         | -                   | -       |
 | **disabled**        | disable current option | `boolean`        | -                   | `false` |
+| **divider**         | display a line         | `boolean`        | -                   | `false` |
+| **label**           | display a group title  | `boolean`        | -                   | `false` |
 | ...                 | native props           | `HTMLAttributes` | `'name', 'id', ...` | -       |
 
 <Attributes.Title>SelectRef</Attributes.Title>

--- a/pages/en-us/components/select.mdx
+++ b/pages/en-us/components/select.mdx
@@ -199,58 +199,69 @@ Display a dropdown list of items.
   code={`
 () => {
   const { visible, setVisible, bindings } = useModal()
-    return (
-      <>
-        <Button auto onClick={() => setVisible(true)}>Show Select</Button>
-        <Modal {...bindings}>
-          <Modal.Title>Modal</Modal.Title>
-          <Modal.Content id="customModalSelect">
-            <Select placeholder="Choose one" initialValue="1"
-              getPopupContainer={() => document.getElementById('customModalSelect')}>
-              <Select.Option value="1"><Code>TypeScript</Code></Select.Option>
-              <Select.Option value="2"><Code>JavaScript</Code></Select.Option>
-            </Select>
-            <p>Scroll through the content to see the changes.</p>
-            <div style={{ height: '1200px' }}></div>
-            <p>Scroll through the content to see the changes.</p>
-          </Modal.Content>
-          <Modal.Action passive onClick={() => setVisible(false)}>Cancel</Modal.Action>
-        </Modal>
-      </>
-    )
-}
-`}
+  return (
+    <>
+      <Button auto onClick={() => setVisible(true)}>Show Select</Button>
+      <Modal {...bindings}>
+        <Modal.Title>Modal</Modal.Title>
+        <Modal.Content id="customModalSelect">
+          <Select placeholder="Choose one" initialValue="1"
+            getPopupContainer={() => document.getElementById('customModalSelect')}>
+            <Select.Option value="1"><Code>TypeScript</Code></Select.Option>
+            <Select.Option value="2"><Code>JavaScript</Code></Select.Option>
+          </Select>
+          <p>Scroll through the content to see the changes.</p>
+          <div style={{ height: '1200px' }}></div>
+          <p>Scroll through the content to see the changes.</p>
+        </Modal.Content>
+        <Modal.Action passive onClick={() => setVisible(false)}>Cancel</Modal.Action>
+      </Modal>
+    </>
+  )
+}`}
 />
 
 <Attributes edit="/pages/en-us/components/select.mdx">
 <Attributes.Title>Select.Props</Attributes.Title>
 
-| Attribute             | Description                                              | Type                                                | Accepted values                   | Default         |
-| --------------------- | -------------------------------------------------------- | --------------------------------------------------- | --------------------------------- | --------------- |
-| **value**             | selected value                                           | `string`, `string[]`                                | -                                 | -               |
-| **initialValue**      | initial value                                            | `string`, `string[]`                                | -                                 | -               |
-| **placeholder**       | placeholder string                                       | `string`                                            | -                                 | -               |
-| **width**             | css width value of select                                | `string`                                            | -                                 | `initial`       |
-| **type**              | current type                                             | `SelectTypes`                                       | [SelectTypes](#selecttypes)       | `default`       |
-| **icon**              | icon component                                           | `ComponentType`                                     | -                                 | `SVG Component` |
-| **pure**              | remove icon component                                    | `boolean`                                           | -                                 | `false`         |
-| **multiple**          | support multiple selection                               | `boolean`                                           | -                                 | `false`         |
-| **clearable**         | add clear icon on multiple selection (ignored otherwise) | `boolean`                                           | -                                 | `true`          |
-| **disabled**          | disable current radio                                    | `boolean`                                           | -                                 | `false`         |
-| **onChange**          | selected value                                           | <Code>(val: string &#124; string[]) => void </Code> | -                                 | -               |
-| **dropdownClassName** | className of dropdown menu                               | `string`                                            | -                                 | -               |
-| **dropdownStyle**     | style of dropdown menu                                   | `object`                                            | -                                 | -               |
-| **disableMatchWidth** | disable Option from follow Select width                  | `boolean`                                           | -                                 | `false`         |
-| **getPopupContainer** | dropdown render parent element, the default is `body`    | `() => HTMLElement`                                 | -                                 | -               |
-| ...                   | native props                                             | `HTMLAttributes`                                    | `'name', 'alt', 'className', ...` | -               |
+| Attribute                   | Description                                              | Type                                                | Accepted values             | Default         |
+| --------------------------- | -------------------------------------------------------- | --------------------------------------------------- | --------------------------- | --------------- |
+| **value**                   | selected value                                           | `string`, `string[]`                                | -                           | -               |
+| **initialValue**            | initial value                                            | `string`, `string[]`                                | -                           | -               |
+| **placeholder**             | placeholder string                                       | `string`                                            | -                           | -               |
+| **width**                   | css width value of select                                | `string`                                            | -                           | `initial`       |
+| **type**                    | current type                                             | `SelectTypes`                                       | [SelectTypes](#selecttypes) | `default`       |
+| **icon**                    | icon component                                           | `ComponentType`                                     | -                           | `SVG Component` |
+| **pure**                    | remove icon component                                    | `boolean`                                           | -                           | `false`         |
+| **multiple**                | support multiple selection                               | `boolean`                                           | -                           | `false`         |
+| **clearable**               | add clear icon on multiple selection (ignored otherwise) | `boolean`                                           | -                           | `true`          |
+| **disabled**                | disable current radio                                    | `boolean`                                           | -                           | `false`         |
+| **onChange**                | selected value                                           | <Code>(val: string &#124; string[]) => void </Code> | -                           | -               |
+| **dropdownClassName**       | className of dropdown menu                               | `string`                                            | -                           | -               |
+| **dropdownStyle**           | style of dropdown menu                                   | `object`                                            | -                           | -               |
+| **disableMatchWidth**       | disable Option from follow Select width                  | `boolean`                                           | -                           | `false`         |
+| **getPopupContainer**       | dropdown render parent element, the default is `body`    | `() => HTMLElement`                                 | -                           | -               |
+| **onDropdownVisibleChange** | dropdown change events                                   | `(visible: boolean) => void`                        | -                           | -               |
+| **ref**                     | forwardRef                                               | `SelectRef`                                         | [SelectRef](#selectref)     | -               |
+| ...                         | native props                                             | `HTMLAttributes`                                    | `'name', 'alt', ...`        | -               |
 
 <Attributes.Title>Select.Option.Props</Attributes.Title>
 
-| Attribute           | Description            | Type             | Accepted values                  | Default |
-| ------------------- | ---------------------- | ---------------- | -------------------------------- | ------- |
-| **value**(required) | unique ident value     | `string`         | -                                | -       |
-| **disabled**        | disable current option | `boolean`        | -                                | `false` |
-| ...                 | native props           | `HTMLAttributes` | `'name', 'id', 'className', ...` | -       |
+| Attribute           | Description            | Type             | Accepted values     | Default |
+| ------------------- | ---------------------- | ---------------- | ------------------- | ------- |
+| **value**(required) | unique ident value     | `string`         | -                   | -       |
+| **disabled**        | disable current option | `boolean`        | -                   | `false` |
+| ...                 | native props           | `HTMLAttributes` | `'name', 'id', ...` | -       |
+
+<Attributes.Title>SelectRef</Attributes.Title>
+
+```ts
+type SelectRef = {
+  focus: () => void
+  blur: () => void
+  scrollTo?: (options?: ScrollToOptions) => void
+}
+```
 
 <Attributes.Title>SelectTypes</Attributes.Title>
 

--- a/pages/zh-cn/components/select.mdx
+++ b/pages/zh-cn/components/select.mdx
@@ -225,23 +225,35 @@ export const meta = {
 <Attributes edit="/pages/zh-cn/components/select.mdx">
 <Attributes.Title>Select.Props</Attributes.Title>
 
-| 属性                  | 描述                              | 类型                                                | 推荐值                            | 默认            |
-| --------------------- | --------------------------------- | --------------------------------------------------- | --------------------------------- | --------------- |
-| **value**             | 手动设置选择器的值                | `string`, `string[]`                                | -                                 | -               |
-| **initialValue**      | 选择器初始值                      | `string`, `string[]`                                | -                                 | -               |
-| **placeholder**       | 占位文本内容                      | `string`                                            | -                                 | -               |
-| **width**             | 组件的 CSS 宽度值                 | `string`                                            | -                                 | `initial`       |
-| **icon**              | 右侧图标组件                      | `ComponentType`                                     | -                                 | `SVG Component` |
-| **pure**              | 隐藏右侧图标组件                  | `boolean`                                           | -                                 | `false`         |
-| **multiple**          | 是否支持多选                      | `boolean`                                           | -                                 | `false`         |
-| **clearable**         | 多选时是否展示移除图标            | `boolean`                                           | -                                 | `true`          |
-| **disabled**          | 禁用所有的交互                    | `boolean`                                           | -                                 | `false`         |
-| **onChange**          | 选项被选中所触发的事件            | <Code>(val: string &#124; string[]) => void </Code> | -                                 | -               |
-| **dropdownClassName** | 下拉框的自定义类名                | `string`                                            | -                                 | -               |
-| **dropdownStyle**     | 下拉框的自定义样式                | `object`                                            | -                                 | -               |
-| **disableMatchWidth** | 禁止 Option 跟随单选框的宽度      | `boolean`                                           | -                                 | `false`         |
-| **getPopupContainer** | 下拉框渲染的父元素，默认是 `body` | `() => HTMLElement`                                 | -                                 | -               |
-| ...                   | 原生属性                          | `HTMLAttributes`                                    | `'name', 'alt', 'className', ...` | -               |
+| 属性                        | 描述                              | 类型                                                | 推荐值                  | 默认            |
+| --------------------------- | --------------------------------- | --------------------------------------------------- | ----------------------- | --------------- |
+| **value**                   | 手动设置选择器的值                | `string`, `string[]`                                | -                       | -               |
+| **initialValue**            | 选择器初始值                      | `string`, `string[]`                                | -                       | -               |
+| **placeholder**             | 占位文本内容                      | `string`                                            | -                       | -               |
+| **width**                   | 组件的 CSS 宽度值                 | `string`                                            | -                       | `initial`       |
+| **icon**                    | 右侧图标组件                      | `ComponentType`                                     | -                       | `SVG Component` |
+| **pure**                    | 隐藏右侧图标组件                  | `boolean`                                           | -                       | `false`         |
+| **multiple**                | 是否支持多选                      | `boolean`                                           | -                       | `false`         |
+| **clearable**               | 多选时是否展示移除图标            | `boolean`                                           | -                       | `true`          |
+| **disabled**                | 禁用所有的交互                    | `boolean`                                           | -                       | `false`         |
+| **onChange**                | 选项被选中所触发的事件            | <Code>(val: string &#124; string[]) => void </Code> | -                       | -               |
+| **dropdownClassName**       | 下拉框的自定义类名                | `string`                                            | -                       | -               |
+| **dropdownStyle**           | 下拉框的自定义样式                | `object`                                            | -                       | -               |
+| **disableMatchWidth**       | 禁止 Option 跟随单选框的宽度      | `boolean`                                           | -                       | `false`         |
+| **getPopupContainer**       | 下拉框渲染的父元素，默认是 `body` | `() => HTMLElement`                                 | -                       | -               |
+| **onDropdownVisibleChange** | 下拉框可见性变化事件              | `(visible: boolean) => void`                        | -                       | -               |
+| **ref**                     | 转发的 Ref                        | `SelectRef`                                         | [SelectRef](#selectref) | -               |
+| ...                         | 原生属性                          | `HTMLAttributes`                                    | `'name', 'alt', ...`    | -               |
+
+<Attributes.Title>SelectRef</Attributes.Title>
+
+```ts
+type SelectRef = {
+  focus: () => void
+  blur: () => void
+  scrollTo?: (options?: ScrollToOptions) => void
+}
+```
 
 <Attributes.Title>Select.Option.Props</Attributes.Title>
 

--- a/pages/zh-cn/components/select.mdx
+++ b/pages/zh-cn/components/select.mdx
@@ -257,11 +257,13 @@ type SelectRef = {
 
 <Attributes.Title>Select.Option.Props</Attributes.Title>
 
-| 属性              | 描述         | 类型             | 推荐值                           | 默认    |
-| ----------------- | ------------ | ---------------- | -------------------------------- | ------- |
-| **value**(必须的) | 唯一鉴别值   | `string`         | -                                | -       |
-| **disabled**      | 禁用当前选项 | `boolean`        | -                                | `false` |
-| ...               | 原生属性     | `HTMLAttributes` | `'name', 'id', 'className', ...` | -       |
+| 属性              | 描述           | 类型             | 推荐值                           | 默认    |
+| ----------------- | -------------- | ---------------- | -------------------------------- | ------- |
+| **value**(必须的) | 唯一鉴别值     | `string`         | -                                | -       |
+| **disabled**      | 禁用当前选项   | `boolean`        | -                                | `false` |
+| **divider**       | 显示线条       | `boolean`        | -                                | `false` |
+| **label**         | 显示分组的标题 | `boolean`        | -                                | `false` |
+| ...               | 原生属性       | `HTMLAttributes` | `'name', 'id', 'className', ...` | -       |
 
 </Attributes>
 


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

- When `blur` is called, Select loses focus and closes the dropdown element.
- When `focus` is called, Select gets focus but does not open the dropdown element.
- The scrollTo function only works after the `onDropdownVisibleChange` event has been triggered, because before that, the dropdown had not yet started rendering.
- Tab presses trigger the focus event correctly, however, no more keyboard event interactions are currently added.



