### PR TITLE
Allow for disableing auto Page.Content insertion.

### DIFF
--- a/components/page/page.tsx
+++ b/components/page/page.tsx
@@ -83,7 +83,7 @@ const Page: React.FC<React.PropsWithChildren<NoteProps>> = ({
 
   return (
     <section className={className} {...props}>
-      {(hasContent || noAutoPageContent) ? children : <PageContent>{children}</PageContent>}
+      {hasContent || noAutoPageContent ? children : <PageContent>{children}</PageContent>}
       {showDot && <DotStyles />}
       <style jsx>{`
         section {

--- a/components/page/page.tsx
+++ b/components/page/page.tsx
@@ -22,6 +22,7 @@ const defaultProps = {
   size: 'medium' as PageSize,
   render: 'default' as PageRenderMode,
   dotBackdrop: false,
+  noAutoPageContent: false,
 }
 
 const DotStyles: React.FC<unknown> = () => (
@@ -47,6 +48,7 @@ const Page: React.FC<React.PropsWithChildren<NoteProps>> = ({
   render,
   dotBackdrop,
   className,
+  noAutoPageContent,
   ...props
 }) => {
   const theme = useTheme()
@@ -81,7 +83,7 @@ const Page: React.FC<React.PropsWithChildren<NoteProps>> = ({
 
   return (
     <section className={className} {...props}>
-      {hasContent ? children : <PageContent>{children}</PageContent>}
+      {(hasContent || noAutoPageContent) ? children : <PageContent>{children}</PageContent>}
       {showDot && <DotStyles />}
       <style jsx>{`
         section {


### PR DESCRIPTION
## Checklist

- [X] Fix linting errors
- [ ] Tests have been added / updated (or snapshots)

## Change information

Allows for using Page with [persistent layouts](https://nextjs.org/docs/basic-features/layouts) in Nextjs. The following example will insert an extra Page.Content around the Home component.

```tsx
export default function Home() {
  return (
    <>
      <Page.Header>
        <Text>header</Text>
      </Page.Header>
      <Page.Content>
        <Text>content</Text>
      </Page.Content>
      <Page.Footer>
        <Text>footer</Text>
      </Page.Footer>
    </>
  );
}

Home.getLayout = function getLayout(page: ReactElement) {
  return <Page>{page}</Page>;
};
```
With this change you can add `noAutoPageContent` to `Page` to disable this.
