### PR TITLE
fix(docs): components/input types not working in zh-CN docs

### DIFF
--- a/pages/zh-cn/components/input.mdx
+++ b/pages/zh-cn/components/input.mdx
@@ -98,13 +98,13 @@ export const meta = {
   scope={{ Input, Spacer }}
   code={`
 <>
-  <Input status="secondary" initialValue="次要" />
+  <Input type="secondary" initialValue="次要" />
   <Spacer h={.5} />
-  <Input status="success" initialValue="成功" />
+  <Input type="success" initialValue="成功" />
   <Spacer h={.5} />
-  <Input status="warning" initialValue="警告" />
+  <Input type="warning" initialValue="警告" />
   <Spacer h={.5} />
-  <Input status="error" initialValue="包含错误" />
+  <Input type="error" initialValue="包含错误" />
 </>
 `}
 />


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information
Change `status="secondary"` to `type="secondary"` in the `input` component doc.
