### PR TITLE
fix: components' `displayName` typos

### DIFF
--- a/components/select/select-input.tsx
+++ b/components/select/select-input.tsx
@@ -52,5 +52,5 @@ const SelectInput = React.forwardRef<HTMLInputElement | null, SelectInputProps>(
   },
 )
 
-SelectInput.displayName = 'GiestSelectInput'
+SelectInput.displayName = 'GeistSelectInput'
 export default SelectInput

--- a/components/table/table-column.tsx
+++ b/components/table/table-column.tsx
@@ -48,5 +48,5 @@ const TableColumn = <TableDataItem extends TableDataItemBase>(
 }
 
 TableColumn.defaultProps = defaultProps
-TableColumn.displayName = 'GiestTableColumn'
+TableColumn.displayName = 'GeistTableColumn'
 export default TableColumn

--- a/components/table/table-head.tsx
+++ b/components/table/table-head.tsx
@@ -15,7 +15,7 @@ const defaultProps = {
 type NativeAttrs = Omit<React.HTMLAttributes<any>, keyof Props<any>>
 export type TableHeadProps<TableDataItem> = Props<TableDataItem> & NativeAttrs
 
-const makeColgroup = <TableDataItem,>(
+const makeColgroup = <TableDataItem>(
   width: number,
   columns: Array<TableAbstractColumn<TableDataItem>>,
 ) => {

--- a/components/table/table-head.tsx
+++ b/components/table/table-head.tsx
@@ -15,7 +15,7 @@ const defaultProps = {
 type NativeAttrs = Omit<React.HTMLAttributes<any>, keyof Props<any>>
 export type TableHeadProps<TableDataItem> = Props<TableDataItem> & NativeAttrs
 
-const makeColgroup = <TableDataItem>(
+const makeColgroup = <TableDataItem,>(
   width: number,
   columns: Array<TableAbstractColumn<TableDataItem>>,
 ) => {

--- a/components/tabs/tabs-item.tsx
+++ b/components/tabs/tabs-item.tsx
@@ -107,7 +107,7 @@ const TabsItemComponent: React.FC<React.PropsWithChildren<TabsItemProps>> = ({
       </div>
     )
   }
-  TabsInternalCell.displayName = 'GiestTabsInternalCell'
+  TabsInternalCell.displayName = 'GeistTabsInternalCell'
 
   useEffect(() => {
     register && register({ value, cell: TabsInternalCell })

--- a/components/tooltip/tooltip.tsx
+++ b/components/tooltip/tooltip.tsx
@@ -130,6 +130,6 @@ const TooltipComponent: React.FC<React.PropsWithChildren<TooltipProps>> = ({
 }
 
 TooltipComponent.defaultProps = defaultProps
-TooltipComponent.displayName = 'GiestTooltip'
+TooltipComponent.displayName = 'GeistTooltip'
 const Tooltip = withScaleable(TooltipComponent)
 export default Tooltip

--- a/components/tree/tree-folder-icon.tsx
+++ b/components/tree/tree-folder-icon.tsx
@@ -40,5 +40,5 @@ const TreeFolderIcon: React.FC<TreeFolderIconProps> = ({
 }
 
 TreeFolderIcon.defaultProps = defaultProps
-TreeFolderIcon.displayName = 'GiestTreeFolderIcon'
+TreeFolderIcon.displayName = 'GeistTreeFolderIcon'
 export default TreeFolderIcon


### PR DESCRIPTION
## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

This PR fixes #611 typos on some components' `displayName`