### PR TITLE
fix(select): option horizontal overflow

### DIFF
--- a/components/select/select-option.tsx
+++ b/components/select/select-option.tsx
@@ -88,6 +88,7 @@ const SelectOptionComponent: React.FC<React.PropsWithChildren<SelectOptionProps>
         .option {
           display: flex;
           max-width: 100%;
+          box-sizing: border-box;
           justify-content: flex-start;
           align-items: center;
           font-weight: normal;


### PR DESCRIPTION
Fixes #613.

## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

The box dimensions of the `Select.Option` component was not taking spacing into consideration. Declaring the box sizing fits the option inside the select dropdown.

## Screenshots

| `master` | This PR |
| --------- | -------- |
| ![image](https://user-images.githubusercontent.com/26530524/144952123-04329dd3-393d-4b00-b5a1-40d35a90bdf1.png) | ![image](https://user-images.githubusercontent.com/26530524/144952097-75da58a3-ec7b-4adb-ad68-d1359eef0f48.png) |