### PR TITLE
fix: Add alt text for image to avoid eslint warn

### DIFF
--- a/examples/create-next-app/pages/index.tsx
+++ b/examples/create-next-app/pages/index.tsx
@@ -25,7 +25,7 @@ export default function Home() {
               and start learning more !
             </>
           }>
-          <Image src="/geist-banner.png" draggable={false} />
+          <Image src="/geist-banner.png" alt="geist ui banner" draggable={false} />
         </Display>
         <Grid.Container justify="center" gap={3} mt="100px">
           <Grid xs={20} sm={7} justify="center">


### PR DESCRIPTION
Have been getting an annoying warning message from eslint:
`Image elements must have an alt prop, either with meaningful text, or an empty string for decorative images.eslintjsx-a11y/alt-text`
![image](https://user-images.githubusercontent.com/54525904/149800492-b7f1f4ef-4dd9-46c2-bfe7-4696ef5b01fc.png)

## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

## Change information

